### PR TITLE
fix: add pre-built Linux x86_64 binary to releases (fixes #1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
             target: aarch64-apple-darwin
             artifact: zero-drift-chat-macos-aarch64
             binary: zero-drift-chat
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            artifact: zero-drift-chat-linux-x86_64
+            binary: zero-drift-chat
 
     runs-on: ${{ matrix.os }}
 
@@ -65,3 +69,4 @@ jobs:
           files: |
             artifacts/zero-drift-chat-windows-x86_64.exe/zero-drift-chat-windows-x86_64.exe
             artifacts/zero-drift-chat-macos-aarch64/zero-drift-chat-macos-aarch64
+            artifacts/zero-drift-chat-linux-x86_64/zero-drift-chat-linux-x86_64

--- a/install.sh
+++ b/install.sh
@@ -15,9 +15,15 @@ case "$OS" in
     ASSET="zero-drift-chat-macos-aarch64"
     ;;
   Linux)
-    echo "Error: No Linux binary available yet. Build from source:"
-    echo "  cargo install --git https://github.com/$REPO"
-    exit 1
+    case "$ARCH" in
+      x86_64) ASSET="zero-drift-chat-linux-x86_64" ;;
+      *)
+        echo "Error: No Linux $ARCH binary available. Build from source (requires nightly Rust):"
+        echo "  rustup toolchain install nightly"
+        echo "  cargo +nightly install --git https://github.com/$REPO"
+        exit 1
+        ;;
+    esac
     ;;
   MINGW*|MSYS*|CYGWIN*)
     echo "On Windows, use PowerShell instead:"


### PR DESCRIPTION
## Summary

- Add `ubuntu-22.04` / `x86_64-unknown-linux-gnu` to the release build matrix so a Linux binary is produced and uploaded on every tag push
- Pin to `ubuntu-22.04` for a stable glibc 2.35 baseline (avoids runtime failures on older distros)
- Update `install.sh` to detect Linux x86_64 and download the binary instead of erroring out; unsupported Linux architectures get a clear error pointing to nightly Rust build instructions

## Test Plan

- [ ] Push a `v*` tag and confirm three build jobs complete (Windows, macOS, Linux)
- [ ] Confirm `zero-drift-chat-linux-x86_64` appears as a release asset
- [ ] On WSL2/Ubuntu x86_64: run `curl -fsSL .../install.sh | bash` and confirm binary installs and runs
- [ ] On an unsupported Linux arch: confirm the new error message with nightly Rust instructions is shown

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)