### PR TITLE
ci: build on master push, publish release on v* tags only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   push:
+    branches: [master]
     tags:
       - 'v*'
 
@@ -52,6 +53,7 @@ jobs:
 
   release:
     needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

- Add `push.branches: [master]` trigger so every merge to master runs a build across all 3 platforms (Windows, macOS, Linux) as a CI check
- Gate the `release` job behind `startsWith(github.ref, 'refs/tags/v')` so GitHub Releases with downloadable binaries are only published when a `v*` tag is pushed — not on every master merge

## Behaviour After This Change

| Event | Build runs | GitHub Release created |
|---|---|---|
| PR opened / updated | ✗ | ✗ |
| Merge to `master` | ✓ (all 3 platforms) | ✗ |
| Push `v1.2.3` tag | ✓ (all 3 platforms) | ✓ |

## Test Plan

- [ ] Merge this PR and confirm the build job runs (no release job)
- [ ] Push a `v*` tag and confirm both build and release jobs run, and a GitHub Release is created with all 3 binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)