### PR TITLE
feat: tui-textarea integration, multi-line input, WSL send key fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,7 +1770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -1787,7 +1787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2724,6 +2724,17 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tui-textarea"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
+dependencies = [
+ "crossterm",
+ "ratatui",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -3723,6 +3734,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "tui-textarea",
  "unicode-width 0.2.0",
  "uuid",
  "whatsapp-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ rand = "0.8"
 dirs = "5"
 whatsapp-rust = { git = "https://github.com/jlucaso1/whatsapp-rust", default-features = true }
 qrcode = "0.14"
+tui-textarea = { version = "0.7", features = ["crossterm"] }

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,18 @@
+# Features
+
+## Messaging
+- Real WhatsApp messaging — send and receive from your terminal
+- QR code authentication rendered directly in the terminal
+- Session persistence — scan once, auto-reconnects on restart
+- WhatsApp history sync — auto-populates chat list with group names and contacts
+- SQLite message storage with full chat history
+- Mock provider for testing without a WhatsApp account
+
+## Interface
+- 3-panel TUI: chat list | message view | input bar
+- Multi-line input — `Enter` inserts a newline, `Shift+Enter` / `Alt+Enter` sends
+- Cursor navigation in input — arrow keys, `Home`, `End`, `Ctrl+U` to clear
+- Vim-style keybindings (`j`/`k` navigate, `i` to type, `Tab` to switch panels)
+- In-app settings overlay — toggle providers and log level without editing files
+- Chat rename — press `r` to set custom display names (persisted across restarts)
+- Version displayed in status bar

--- a/README.md
+++ b/README.md
@@ -4,24 +4,13 @@ A unified messaging TUI built in Rust. Aggregates multiple chat platforms into a
 
 Currently supports **WhatsApp** via [whatsapp-rust](https://github.com/jlucaso1/whatsapp-rust) (WhatsApp Web multi-device protocol).
 
-## Features
-
-- Real WhatsApp messaging — send and receive from your terminal
-- QR code authentication rendered directly in the terminal
-- Session persistence — scan once, auto-reconnects on restart
-- 3-panel TUI: chat list | message view | input bar
-- Vim-style keybindings (j/k navigate, i to type, Tab to switch panels)
-- In-app settings overlay — toggle providers and log level without editing files
-- Chat rename — press `r` to set custom display names (persisted across restarts)
-- WhatsApp history sync — auto-populates chat list with group names and contacts
-- SQLite message storage with full chat history
-- Mock provider for testing without a WhatsApp account
+See [FEATURES.md](FEATURES.md) for the full feature list.
 
 ## Install
 
 ### From release (no Rust needed)
 
-**macOS:**
+**macOS / Linux / WSL:**
 ```bash
 curl -fsSL https://raw.githubusercontent.com/mgblackwater/zero-drift-chat/master/install.sh | bash
 ```
@@ -33,10 +22,14 @@ irm https://raw.githubusercontent.com/mgblackwater/zero-drift-chat/master/instal
 
 ### From source
 
-Requires [Rust nightly](https://rustup.rs/):
+Requires [Rust nightly](https://rustup.rs/) (selected automatically via `rust-toolchain.toml`):
 
 ```bash
+# Install from git
 cargo install --git https://github.com/mgblackwater/zero-drift-chat
+
+# Or install from a local clone
+cargo install --path .
 ```
 
 ## Usage
@@ -65,7 +58,10 @@ On first launch with WhatsApp enabled, a QR code appears. Scan it with WhatsApp 
 
 | Key | Action |
 |-----|--------|
-| `Enter` | Send message |
+| `Enter` | Insert newline |
+| `Shift+Enter` / `Alt+Enter` | Send message |
+| `← →` / `Home` / `End` | Move cursor |
+| `Ctrl+U` | Clear input |
 | `Esc` | Back to normal mode |
 
 **Settings overlay:**

--- a/docs/plans/2026-03-04-input-improvements-design.md
+++ b/docs/plans/2026-03-04-input-improvements-design.md
@@ -1,0 +1,94 @@
+# Input Improvements Design
+
+**Date:** 2026-03-04
+**Issues:** [#5 Input box scrolling bug](https://github.com/mgblackwater/zero-drift-chat/issues/5), [#2 Keyboard navigation & multi-line input](https://github.com/mgblackwater/zero-drift-chat/issues/2)
+
+## Problem
+
+1. **Bug #5:** Text typed beyond the visible width of the input box is not shown — no horizontal scroll, no cursor tracking past the edge.
+2. **Issue #2 (priority scope):** No arrow-key cursor movement, no multi-line input, Enter always sends immediately.
+
+## Decision
+
+Replace the custom input box with **`tui-textarea`** — a ratatui-compatible widget that handles cursor movement, multi-line editing, horizontal/vertical scroll, Unicode boundaries, and Home/End out of the box. This eliminates ~150 lines of custom cursor/scroll logic in exchange for ~20 lines of integration code.
+
+**Rejected alternatives:**
+- Extend the String buffer with manual scroll offset: more code, more edge cases (Unicode, wrap, multi-line)
+- `Vec<String>` per-line cursor: explicit but equally complex, still needs all the same scroll logic
+
+## Keybindings
+
+| Key | Action | Platform notes |
+|---|---|---|
+| `Enter` | Insert newline | All |
+| `Shift+Enter` | Send message | Windows Terminal, iTerm2, modern macOS terminals, WSL |
+| `Alt+Enter` | Send message | macOS Terminal.app fallback; works on all mainstream terminals |
+| `Ctrl+U` | Clear entire input buffer | All (custom override — tui-textarea default is delete-to-line-start) |
+| `← →` | Move cursor left/right | All |
+| `↑ ↓` | Move cursor up/down (multi-line) | All |
+| `Home` / `End` | Start / end of line | All (macOS: Fn+← / Fn+→) |
+| `Backspace` | Delete character | All |
+| all other keys | Forwarded to TextArea natively | — |
+
+Both `Shift+Enter` and `Alt+Enter` fire the same `SubmitMessage` action.
+
+## Architecture
+
+### Dependency
+
+```toml
+# Cargo.toml
+tui-textarea = "0.7"
+```
+
+### State (`src/tui/app_state.rs`)
+
+Remove:
+- `pub input_buffer: String`
+- `pub cursor_position: usize`
+- `push_char()`, `delete_char()`
+
+Add:
+- `pub input: TextArea<'static>`
+
+Update:
+- `take_input()` → returns `self.input.lines().join("\n")` and resets `self.input = TextArea::default()`
+- New action handler for `ClearInput` → `self.input = TextArea::default()`
+
+### Key handling (`src/tui/keybindings.rs` + `src/app.rs`)
+
+In editing mode, intercept before forwarding to TextArea:
+- `Shift+Enter` or `Alt+Enter` → `AppAction::SubmitMessage`
+- `Ctrl+U` → `AppAction::ClearInput`
+- `Esc` → `AppAction::ExitEditing`
+- everything else → `state.input.input(key_event)` (TextArea handles it, returns bool indicating whether text changed)
+
+Remove `AppAction::InsertChar` and `AppAction::DeleteChar`.
+
+### Rendering (`src/tui/widgets/input_bar.rs`)
+
+Replace:
+```rust
+// Before: manual Paragraph + set_cursor_position
+let paragraph = Paragraph::new(text)...;
+f.render_widget(paragraph, inner);
+f.set_cursor_position((x, y));
+```
+
+With:
+```rust
+// After: TextArea widget (handles cursor, scroll, multi-line automatically)
+f.render_widget(state.input.widget(), inner);
+```
+
+The input bar block/border stays as-is; only the inner widget changes.
+
+## Scope
+
+Four files changed:
+- `Cargo.toml` — add dependency
+- `src/tui/app_state.rs` — replace input state
+- `src/tui/keybindings.rs` — update editing-mode key map
+- `src/tui/widgets/input_bar.rs` — update render
+
+No changes to chat list, message view, or any other component.

--- a/docs/plans/2026-03-04-input-improvements.md
+++ b/docs/plans/2026-03-04-input-improvements.md
@@ -1,0 +1,440 @@
+# Input Improvements Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the custom input box with `tui-textarea` to fix the text-hidden-when-long bug (#5) and add cursor navigation, multi-line input, and cross-platform send keybindings (#2).
+
+**Architecture:** Four sequential tasks touching five files. `tui-textarea` handles all cursor/scroll/Unicode logic; we intercept only three special keys (Esc, send, clear) before forwarding the rest. The Renaming mode is migrated alongside Editing to use the same TextArea field.
+
+**Tech Stack:** Rust, ratatui 0.29, tui-textarea 0.7, crossterm 0.28
+
+---
+
+### Task 1: Add tui-textarea dependency
+
+**Files:**
+- Modify: `Cargo.toml`
+
+**Step 1: Add the dependency**
+
+Open `Cargo.toml`. The `[dependencies]` section currently ends around line 26 with `qrcode = "0.14"`. Add one line after it:
+
+```toml
+tui-textarea = { version = "0.7", features = ["crossterm"] }
+```
+
+The `crossterm` feature enables `impl From<crossterm::event::KeyEvent> for tui_textarea::Input`, which is needed to forward key events directly.
+
+**Step 2: Verify it resolves**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat
+cargo check 2>&1 | tail -5
+```
+
+Expected: ends with `warning: ...` lines or `Finished checking`. No `error` lines.
+
+**Step 3: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "deps: add tui-textarea 0.7 for input improvements"
+```
+
+---
+
+### Task 2: Migrate AppState from input_buffer/cursor_position to TextArea
+
+**Files:**
+- Modify: `src/tui/app_state.rs`
+
+**Context:** `AppState` (line 127) currently has `input_buffer: String` (line 133) and `cursor_position: usize` (line 134). The methods `push_char()` (line 224), `delete_char()` (line 229), and `take_input()` (line 241) manage them. `enter_editing()` (line 215) and `exit_editing()` (line 220) toggle `input_mode`.
+
+**Step 1: Add the import**
+
+At the top of `src/tui/app_state.rs`, add after `use ratatui::widgets::ListState;`:
+
+```rust
+use tui_textarea::TextArea;
+```
+
+**Step 2: Replace the two fields in the AppState struct**
+
+Replace lines 133–134:
+```rust
+    pub input_buffer: String,
+    pub cursor_position: usize,
+```
+
+With:
+```rust
+    pub input: TextArea<'static>,
+```
+
+**Step 3: Update AppState::new()**
+
+Replace lines 154–155 in `new()`:
+```rust
+            input_buffer: String::new(),
+            cursor_position: 0,
+```
+
+With:
+```rust
+            input: TextArea::default(),
+```
+
+**Step 4: Remove push_char() and delete_char(), update take_input()**
+
+Remove the entire `push_char()` method (lines 224–227) and the entire `delete_char()` method (lines 229–239).
+
+Replace the `take_input()` method (lines 241–244) with:
+
+```rust
+    pub fn take_input(&mut self) -> String {
+        let text = self.input.lines().join("\n");
+        self.input = TextArea::default();
+        text
+    }
+```
+
+**Step 5: Verify compilation**
+
+```bash
+cargo check 2>&1 | grep "^error" | head -20
+```
+
+Expected: errors referencing `input_buffer` and `cursor_position` in `src/app.rs` — these are expected at this stage because `app.rs` still references the old fields. Zero errors in `app_state.rs` itself.
+
+**Step 6: Commit**
+
+```bash
+git add src/tui/app_state.rs
+git commit -m "refactor: replace input_buffer/cursor_position with TextArea in AppState"
+```
+
+---
+
+### Task 3: Update keybindings.rs
+
+**Files:**
+- Modify: `src/tui/keybindings.rs`
+
+**Context:** The `Action` enum (line 6) has `DeleteChar` (line 14) and `InsertChar(char)` (line 15). `map_editing_mode()` (line 55) maps `Enter` to `SubmitMessage` and chars to `InsertChar`. `map_renaming_mode()` (line 76) also uses `DeleteChar` and `InsertChar`.
+
+**Step 1: Update the Action enum**
+
+Replace the entire `Action` enum (lines 5–28) with:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Action {
+    Quit,
+    SwitchPanel,
+    NextChat,
+    PrevChat,
+    EnterEditing,
+    ExitEditing,
+    SubmitMessage,
+    ClearInput,
+    InputKey(KeyEvent),
+    ScrollUp,
+    ScrollDown,
+    OpenSettings,
+    SettingsNext,
+    SettingsPrev,
+    SettingsToggle,
+    SettingsSave,
+    SettingsClose,
+    RenameChat,
+    ConfirmRename,
+    CancelRename,
+    None,
+}
+```
+
+`DeleteChar` and `InsertChar(char)` are removed. `ClearInput` and `InputKey(KeyEvent)` are added.
+
+**Step 2: Replace map_editing_mode()**
+
+Replace the entire `map_editing_mode()` function (lines 55–63) with:
+
+```rust
+fn map_editing_mode(key: KeyEvent) -> Action {
+    match (key.code, key.modifiers) {
+        (KeyCode::Esc, _) => Action::ExitEditing,
+        // Shift+Enter: works on Windows Terminal, iTerm2, modern macOS terminals, WSL
+        (KeyCode::Enter, m) if m.contains(KeyModifiers::SHIFT) => Action::SubmitMessage,
+        // Alt+Enter: fallback for macOS Terminal.app and other terminals
+        (KeyCode::Enter, m) if m.contains(KeyModifiers::ALT) => Action::SubmitMessage,
+        // Ctrl+U: clear entire buffer (override tui-textarea default of delete-to-line-start)
+        (KeyCode::Char('u'), m) if m.contains(KeyModifiers::CONTROL) => Action::ClearInput,
+        // All other keys forwarded to TextArea (handles arrows, backspace, enter=newline, home/end, etc.)
+        _ => Action::InputKey(key),
+    }
+}
+```
+
+**Step 3: Replace map_renaming_mode()**
+
+Replace the entire `map_renaming_mode()` function (lines 76–84) with:
+
+```rust
+fn map_renaming_mode(key: KeyEvent) -> Action {
+    match (key.code, key.modifiers) {
+        (KeyCode::Esc, _) => Action::CancelRename,
+        // Plain Enter confirms rename (single-line context, no multi-line needed)
+        (KeyCode::Enter, m) if m == KeyModifiers::NONE => Action::ConfirmRename,
+        // All other keys forwarded to TextArea (handles arrows, backspace, home/end)
+        _ => Action::InputKey(key),
+    }
+}
+```
+
+**Step 4: Verify compilation**
+
+```bash
+cargo check 2>&1 | grep "^error" | head -20
+```
+
+Expected: errors in `src/app.rs` only (still references `DeleteChar`, `InsertChar`, `input_buffer`, `cursor_position`). Zero errors in `keybindings.rs`.
+
+**Step 5: Commit**
+
+```bash
+git add src/tui/keybindings.rs
+git commit -m "refactor: replace InsertChar/DeleteChar actions with InputKey/ClearInput"
+```
+
+---
+
+### Task 4: Update app.rs action handler
+
+**Files:**
+- Modify: `src/app.rs`
+
+**Context:** `handle_action()` (line 297) handles `DeleteChar` (line 352), `InsertChar` (line 355), `RenameChat` (line 396), `CancelRename` (line 422). `RenameChat` directly writes to `self.state.input_buffer` (line 404) and `self.state.cursor_position` (line 405). `CancelRename` clears them (lines 423–425).
+
+**Step 1: Add the tui_textarea import**
+
+At the top of `src/app.rs`, add to the existing use statements:
+
+```rust
+use tui_textarea::TextArea;
+```
+
+**Step 2: Replace DeleteChar and InsertChar handlers**
+
+Remove lines 352–357:
+```rust
+            Action::DeleteChar => {
+                self.state.delete_char();
+            }
+            Action::InsertChar(c) => {
+                self.state.push_char(c);
+            }
+```
+
+Replace with:
+```rust
+            Action::InputKey(key) => {
+                self.state.input.input(key);
+            }
+            Action::ClearInput => {
+                self.state.input = TextArea::default();
+            }
+```
+
+**Step 3: Replace RenameChat handler**
+
+Replace lines 396–409:
+```rust
+            Action::RenameChat => {
+                if let Some(idx) = self.state.chat_list_state.selected() {
+                    if let Some(chat) = self.state.chats.get(idx) {
+                        let name = chat
+                            .display_name
+                            .as_ref()
+                            .unwrap_or(&chat.name)
+                            .clone();
+                        self.state.input_buffer = name;
+                        self.state.cursor_position = self.state.input_buffer.len();
+                        self.state.input_mode = InputMode::Renaming;
+                    }
+                }
+            }
+```
+
+With:
+```rust
+            Action::RenameChat => {
+                if let Some(idx) = self.state.chat_list_state.selected() {
+                    if let Some(chat) = self.state.chats.get(idx) {
+                        let name = chat
+                            .display_name
+                            .as_ref()
+                            .unwrap_or(&chat.name)
+                            .clone();
+                        let mut ta = TextArea::from(vec![name]);
+                        ta.move_cursor(tui_textarea::CursorMove::End);
+                        self.state.input = ta;
+                        self.state.input_mode = InputMode::Renaming;
+                    }
+                }
+            }
+```
+
+**Step 4: Replace CancelRename handler**
+
+Replace lines 422–426:
+```rust
+            Action::CancelRename => {
+                self.state.input_buffer.clear();
+                self.state.cursor_position = 0;
+                self.state.input_mode = InputMode::Normal;
+            }
+```
+
+With:
+```rust
+            Action::CancelRename => {
+                self.state.input = TextArea::default();
+                self.state.input_mode = InputMode::Normal;
+            }
+```
+
+**Step 5: Verify compilation**
+
+```bash
+cargo check 2>&1 | grep "^error" | head -20
+```
+
+Expected: errors only in `src/tui/render.rs` and `src/tui/widgets/input_bar.rs` (still pass old `input_buffer`/`cursor_position` to `render_input_bar`). Zero errors in `app.rs`.
+
+**Step 6: Commit**
+
+```bash
+git add src/app.rs
+git commit -m "refactor: update app.rs to use TextArea for input handling"
+```
+
+---
+
+### Task 5: Update render.rs and input_bar.rs
+
+**Files:**
+- Modify: `src/tui/render.rs`
+- Modify: `src/tui/widgets/input_bar.rs`
+
+**Context:** `render.rs` calls `render_input_bar(f, input_area, &state.input_buffer, state.cursor_position, state.input_mode)` (lines 59–65). `input_bar.rs` renders a `Paragraph` with a mode-tag prefix and positions the hardware cursor manually (lines 11–50).
+
+**Step 1: Rewrite input_bar.rs**
+
+Replace the entire content of `src/tui/widgets/input_bar.rs` with:
+
+```rust
+use ratatui::{
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+use tui_textarea::TextArea;
+
+use crate::tui::app_state::InputMode;
+
+pub fn render_input_bar(
+    f: &mut Frame,
+    area: Rect,
+    textarea: &TextArea<'static>,
+    mode: InputMode,
+) {
+    let (mode_tag, border_color) = match mode {
+        InputMode::Normal => ("NORMAL", Color::DarkGray),
+        InputMode::Editing => ("INSERT", Color::Yellow),
+        InputMode::Settings => ("SETTINGS", Color::Cyan),
+        InputMode::Renaming => ("RENAME", Color::Magenta),
+    };
+
+    let block = Block::default()
+        .title(format!(" [{}] ", mode_tag))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color));
+
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+
+    if mode == InputMode::Editing || mode == InputMode::Renaming {
+        // TextArea widget: handles cursor positioning, scrolling, multi-line display
+        f.render_widget(textarea.widget(), inner_area);
+    } else {
+        // Normal/Settings: render text only, no hardware cursor in the input box
+        let text = textarea.lines().join("\n");
+        f.render_widget(Paragraph::new(text), inner_area);
+    }
+}
+```
+
+Key changes from the old implementation:
+- Mode tag moves from inline text prefix to the block title (cleaner UX)
+- In Editing/Renaming modes: `textarea.widget()` handles cursor display, horizontal scroll, and multi-line rendering automatically
+- In Normal/Settings modes: plain `Paragraph` so the hardware cursor does not appear in the input box
+
+**Step 2: Update the call site in render.rs**
+
+Replace lines 59–65 in `src/tui/render.rs`:
+```rust
+    input_bar::render_input_bar(
+        f,
+        input_area,
+        &state.input_buffer,
+        state.cursor_position,
+        state.input_mode,
+    );
+```
+
+With:
+```rust
+    input_bar::render_input_bar(
+        f,
+        input_area,
+        &state.input,
+        state.input_mode,
+    );
+```
+
+**Step 3: Full build**
+
+```bash
+cargo build 2>&1 | grep "^error" | head -20
+```
+
+Expected: no `error` lines. Warnings about unused code are fine.
+
+**Step 4: Smoke test**
+
+```bash
+cargo run -- --mock 2>&1 &
+```
+
+Verify manually:
+- In Normal mode: input box shows `[NORMAL]` title, no blinking cursor inside
+- Press `i` to enter editing: title changes to `[INSERT]`, cursor appears
+- Type a short message: text appears, cursor moves right
+- Type a very long message (> box width): text scrolls horizontally, cursor stays visible
+- Press `←`/`→`: cursor moves within text
+- Press `Home`/`End`: cursor jumps to start/end of line
+- Press `Enter`: newline inserted (multi-line input)
+- Press `Shift+Enter` or `Alt+Enter`: message sent
+- Press `Ctrl+U`: entire input cleared
+- Press `Esc`: exits editing mode
+- Press `r` to rename a chat: box pre-filled with current name in RENAME mode, arrows work, Enter confirms
+
+Kill the process with `Ctrl+C` when done.
+
+**Step 5: Commit**
+
+```bash
+git add src/tui/widgets/input_bar.rs src/tui/render.rs
+git commit -m "feat: replace input Paragraph with tui-textarea (fixes #5, closes #2 part 1)"
+```

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,6 +15,8 @@ use crate::core::MessageRouter;
 use crate::providers::mock::MockProvider;
 use crate::providers::whatsapp::WhatsAppProvider;
 use crate::storage::{AddressBook, Database};
+use tui_textarea::TextArea;
+
 use crate::tui::app_state::{AppState, InputMode};
 use crate::tui::event::{AppEvent, EventHandler};
 use crate::tui::keybindings::{map_key, Action};
@@ -349,11 +351,11 @@ impl App {
                     }
                 }
             }
-            Action::DeleteChar => {
-                self.state.delete_char();
+            Action::InputKey(key) => {
+                self.state.input.input(key);
             }
-            Action::InsertChar(c) => {
-                self.state.push_char(c);
+            Action::ClearInput => {
+                self.state.input = TextArea::default();
             }
             Action::ScrollUp => {
                 self.state.scroll_up();
@@ -401,8 +403,9 @@ impl App {
                             .as_ref()
                             .unwrap_or(&chat.name)
                             .clone();
-                        self.state.input_buffer = name;
-                        self.state.cursor_position = self.state.input_buffer.len();
+                        let mut ta = TextArea::from(vec![name]);
+                        ta.move_cursor(tui_textarea::CursorMove::End);
+                        self.state.input = ta;
                         self.state.input_mode = InputMode::Renaming;
                     }
                 }
@@ -420,8 +423,7 @@ impl App {
                 self.state.input_mode = InputMode::Normal;
             }
             Action::CancelRename => {
-                self.state.input_buffer.clear();
-                self.state.cursor_position = 0;
+                self.state.input = TextArea::default();
                 self.state.input_mode = InputMode::Normal;
             }
             Action::None => {}

--- a/src/app.rs
+++ b/src/app.rs
@@ -411,7 +411,11 @@ impl App {
                 }
             }
             Action::ConfirmRename => {
-                let new_name = self.state.take_input();
+                let new_name = self.state.input.lines()
+                    .first()
+                    .cloned()
+                    .unwrap_or_default();
+                self.state.input = tui_textarea::TextArea::default();
                 if !new_name.is_empty() {
                     if let Some(idx) = self.state.chat_list_state.selected() {
                         if let Some(chat) = self.state.chats.get_mut(idx) {

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -1,4 +1,5 @@
 use ratatui::widgets::ListState;
+use tui_textarea::TextArea;
 
 use crate::config::AppConfig;
 use crate::core::types::{UnifiedChat, UnifiedMessage};
@@ -130,8 +131,7 @@ pub struct AppState {
     pub chat_list_state: ListState,
     pub active_panel: ActivePanel,
     pub input_mode: InputMode,
-    pub input_buffer: String,
-    pub cursor_position: usize,
+    pub input: TextArea<'static>,
     pub scroll_offset: u16,
     pub should_quit: bool,
     pub qr_code: Option<String>,
@@ -151,8 +151,7 @@ impl AppState {
             chat_list_state,
             active_panel: ActivePanel::ChatList,
             input_mode: InputMode::Normal,
-            input_buffer: String::new(),
-            cursor_position: 0,
+            input: TextArea::default(),
             scroll_offset: 0,
             should_quit: false,
             qr_code: None,
@@ -221,26 +220,10 @@ impl AppState {
         self.input_mode = InputMode::Normal;
     }
 
-    pub fn push_char(&mut self, c: char) {
-        self.input_buffer.insert(self.cursor_position, c);
-        self.cursor_position += c.len_utf8();
-    }
-
-    pub fn delete_char(&mut self) {
-        if self.cursor_position > 0 {
-            let prev = self.input_buffer[..self.cursor_position]
-                .chars()
-                .last()
-                .map(|c| c.len_utf8())
-                .unwrap_or(0);
-            self.cursor_position -= prev;
-            self.input_buffer.remove(self.cursor_position);
-        }
-    }
-
     pub fn take_input(&mut self) -> String {
-        self.cursor_position = 0;
-        std::mem::take(&mut self.input_buffer)
+        let text = self.input.lines().join("\n");
+        self.input = TextArea::default();
+        text
     }
 
     pub fn scroll_up(&mut self) {

--- a/src/tui/keybindings.rs
+++ b/src/tui/keybindings.rs
@@ -59,7 +59,7 @@ fn map_editing_mode(key: KeyEvent) -> Action {
         (KeyCode::Enter, m) if m.contains(KeyModifiers::SHIFT) => Action::SubmitMessage,
         // Alt+Enter: fallback for macOS Terminal.app and other terminals
         (KeyCode::Enter, m) if m.contains(KeyModifiers::ALT) => Action::SubmitMessage,
-        // Ctrl+U: clear entire buffer (override tui-textarea default of delete-to-line-start)
+        // Ctrl+U: clear entire buffer (override tui-textarea default of undo)
         (KeyCode::Char('u'), m) if m.contains(KeyModifiers::CONTROL) => Action::ClearInput,
         // All other keys forwarded to TextArea
         _ => Action::InputKey(key),
@@ -80,9 +80,10 @@ fn map_settings_mode(key: KeyEvent) -> Action {
 fn map_renaming_mode(key: KeyEvent) -> Action {
     match (key.code, key.modifiers) {
         (KeyCode::Esc, _) => Action::CancelRename,
-        // Plain Enter confirms rename (single-line, no multi-line needed)
+        // Plain Enter confirms rename (single-line context)
         (KeyCode::Enter, m) if m == KeyModifiers::NONE => Action::ConfirmRename,
-        // All other keys forwarded to TextArea
+        // Block Shift+Enter / Alt+Enter from inserting newlines into a chat name
+        (KeyCode::Enter, _) => Action::None,
         _ => Action::InputKey(key),
     }
 }

--- a/src/tui/keybindings.rs
+++ b/src/tui/keybindings.rs
@@ -59,6 +59,8 @@ fn map_editing_mode(key: KeyEvent) -> Action {
         (KeyCode::Enter, m) if m.contains(KeyModifiers::SHIFT) => Action::SubmitMessage,
         // Alt+Enter: fallback for macOS Terminal.app and other terminals
         (KeyCode::Enter, m) if m.contains(KeyModifiers::ALT) => Action::SubmitMessage,
+        // Ctrl+S: universal reliable fallback (works on all terminals including WSL)
+        (KeyCode::Char('s'), m) if m.contains(KeyModifiers::CONTROL) => Action::SubmitMessage,
         // Ctrl+U: clear entire buffer (override tui-textarea default of undo)
         (KeyCode::Char('u'), m) if m.contains(KeyModifiers::CONTROL) => Action::ClearInput,
         // All other keys forwarded to TextArea

--- a/src/tui/keybindings.rs
+++ b/src/tui/keybindings.rs
@@ -11,8 +11,8 @@ pub enum Action {
     EnterEditing,
     ExitEditing,
     SubmitMessage,
-    DeleteChar,
-    InsertChar(char),
+    ClearInput,
+    InputKey(KeyEvent),
     ScrollUp,
     ScrollDown,
     OpenSettings,
@@ -53,12 +53,16 @@ fn map_normal_mode(key: KeyEvent) -> Action {
 }
 
 fn map_editing_mode(key: KeyEvent) -> Action {
-    match key.code {
-        KeyCode::Esc => Action::ExitEditing,
-        KeyCode::Enter => Action::SubmitMessage,
-        KeyCode::Backspace => Action::DeleteChar,
-        KeyCode::Char(c) => Action::InsertChar(c),
-        _ => Action::None,
+    match (key.code, key.modifiers) {
+        (KeyCode::Esc, _) => Action::ExitEditing,
+        // Shift+Enter: works on Windows Terminal, iTerm2, modern macOS terminals, WSL
+        (KeyCode::Enter, m) if m.contains(KeyModifiers::SHIFT) => Action::SubmitMessage,
+        // Alt+Enter: fallback for macOS Terminal.app and other terminals
+        (KeyCode::Enter, m) if m.contains(KeyModifiers::ALT) => Action::SubmitMessage,
+        // Ctrl+U: clear entire buffer (override tui-textarea default of delete-to-line-start)
+        (KeyCode::Char('u'), m) if m.contains(KeyModifiers::CONTROL) => Action::ClearInput,
+        // All other keys forwarded to TextArea
+        _ => Action::InputKey(key),
     }
 }
 
@@ -74,11 +78,11 @@ fn map_settings_mode(key: KeyEvent) -> Action {
 }
 
 fn map_renaming_mode(key: KeyEvent) -> Action {
-    match key.code {
-        KeyCode::Esc => Action::CancelRename,
-        KeyCode::Enter => Action::ConfirmRename,
-        KeyCode::Backspace => Action::DeleteChar,
-        KeyCode::Char(c) => Action::InsertChar(c),
-        _ => Action::None,
+    match (key.code, key.modifiers) {
+        (KeyCode::Esc, _) => Action::CancelRename,
+        // Plain Enter confirms rename (single-line, no multi-line needed)
+        (KeyCode::Enter, m) if m == KeyModifiers::NONE => Action::ConfirmRename,
+        // All other keys forwarded to TextArea
+        _ => Action::InputKey(key),
     }
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -23,9 +23,11 @@ pub fn draw(f: &mut Frame, state: &mut AppState) {
     let chat_list_area = body_layout[0];
     let message_area = body_layout[1];
 
+    // Input box grows with content: +2 for borders, clamped between 3 (1 line) and 8 (6 lines)
+    let input_height = (state.input.lines().len() as u16 + 2).clamp(3, 8);
     let message_layout = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(3)])
+        .constraints([Constraint::Min(1), Constraint::Length(input_height)])
         .split(message_area);
 
     let message_view_area = message_layout[0];

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -59,8 +59,7 @@ pub fn draw(f: &mut Frame, state: &mut AppState) {
     input_bar::render_input_bar(
         f,
         input_area,
-        &state.input_buffer,
-        state.cursor_position,
+        &state.input,
         state.input_mode,
     );
 

--- a/src/tui/widgets/input_bar.rs
+++ b/src/tui/widgets/input_bar.rs
@@ -31,7 +31,7 @@ pub fn render_input_bar(
 
     if mode == InputMode::Editing || mode == InputMode::Renaming {
         // TextArea widget: handles cursor, horizontal scroll, multi-line display automatically
-        f.render_widget(textarea.widget(), inner_area);
+        f.render_widget(textarea, inner_area);
     } else {
         // Normal/Settings: render text only, no hardware cursor in the input box
         let text = textarea.lines().join("\n");

--- a/src/tui/widgets/input_bar.rs
+++ b/src/tui/widgets/input_bar.rs
@@ -1,18 +1,17 @@
 use ratatui::{
     layout::Rect,
     style::{Color, Style},
-    text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
     Frame,
 };
+use tui_textarea::TextArea;
 
 use crate::tui::app_state::InputMode;
 
 pub fn render_input_bar(
     f: &mut Frame,
     area: Rect,
-    input: &str,
-    cursor_position: usize,
+    textarea: &TextArea<'static>,
     mode: InputMode,
 ) {
     let (mode_tag, border_color) = match mode {
@@ -22,29 +21,20 @@ pub fn render_input_bar(
         InputMode::Renaming => ("RENAME", Color::Magenta),
     };
 
-    let line = Line::from(vec![
-        Span::styled(
-            format!("[{}] ", mode_tag),
-            Style::default().fg(border_color),
-        ),
-        Span::raw(input),
-    ]);
-
     let block = Block::default()
+        .title(format!(" [{}] ", mode_tag))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
 
-    let paragraph = Paragraph::new(line).block(block);
-    f.render_widget(paragraph, area);
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
 
-    // Show cursor when editing
     if mode == InputMode::Editing || mode == InputMode::Renaming {
-        let prefix_len = mode_tag.len() + 3; // "[MODE] "
-        let byte_pos = cursor_position;
-        let char_offset = input[..byte_pos].chars().count();
-        f.set_cursor_position((
-            area.x + 1 + prefix_len as u16 + char_offset as u16,
-            area.y + 1,
-        ));
+        // TextArea widget: handles cursor, horizontal scroll, multi-line display automatically
+        f.render_widget(textarea.widget(), inner_area);
+    } else {
+        // Normal/Settings: render text only, no hardware cursor in the input box
+        let text = textarea.lines().join("\n");
+        f.render_widget(Paragraph::new(text), inner_area);
     }
 }

--- a/src/tui/widgets/message_view.rs
+++ b/src/tui/widgets/message_view.rs
@@ -55,13 +55,13 @@ pub fn render_message_view(
             Span::styled(time, Style::default().fg(Color::DarkGray)),
         ]);
 
-        let content = Line::from(Span::styled(
-            msg.content.as_text().to_string(),
-            Style::default().fg(msg_color),
-        ));
-
         lines.push(header);
-        lines.push(content);
+        for text_line in msg.content.as_text().split('\n') {
+            lines.push(Line::from(Span::styled(
+                text_line.to_string(),
+                Style::default().fg(msg_color),
+            )));
+        }
         lines.push(Line::from("")); // spacing
     }
 

--- a/src/tui/widgets/status_bar.rs
+++ b/src/tui/widgets/status_bar.rs
@@ -17,12 +17,19 @@ pub fn render_status_bar(
 ) {
     let hints = match mode {
         InputMode::Normal => "q:Quit | Tab:Switch | j/k:Navigate | i:Type | r:Rename | s:Settings",
-        InputMode::Editing => "Esc:Normal | Enter:Send | Type your message",
+        InputMode::Editing => "Esc:Normal | Enter:Newline | Shift+Enter/Alt+Enter:Send | Ctrl+U:Clear",
         InputMode::Settings => "j/k:Navigate | Enter/Space:Toggle | Ctrl+s:Save | Esc:Cancel",
         InputMode::Renaming => "Enter:Confirm | Esc:Cancel | Type new name",
     };
 
     let mut spans = Vec::new();
+
+    // Version
+    spans.push(Span::styled(
+        format!(" v{} ", env!("CARGO_PKG_VERSION")),
+        Style::default().fg(Color::DarkGray),
+    ));
+    spans.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
 
     if mock_enabled {
         spans.push(Span::styled(" ● ", Style::default().fg(Color::Green)));

--- a/src/tui/widgets/status_bar.rs
+++ b/src/tui/widgets/status_bar.rs
@@ -17,7 +17,7 @@ pub fn render_status_bar(
 ) {
     let hints = match mode {
         InputMode::Normal => "q:Quit | Tab:Switch | j/k:Navigate | i:Type | r:Rename | s:Settings",
-        InputMode::Editing => "Esc:Normal | Enter:Newline | Shift+Enter/Alt+Enter:Send | Ctrl+U:Clear",
+        InputMode::Editing => "Esc:Normal | Enter:Newline | Shift+Enter/Alt+Enter/Ctrl+S:Send | Ctrl+U:Clear",
         InputMode::Settings => "j/k:Navigate | Enter/Space:Toggle | Ctrl+s:Save | Esc:Cancel",
         InputMode::Renaming => "Enter:Confirm | Esc:Cancel | Type new name",
     };


### PR DESCRIPTION
## Summary

- Replaces custom input buffer with `tui-textarea` crate — adds cursor navigation (arrow keys, Home, End), multi-line editing, and proper input scrolling (closes #5)
- `Enter` inserts newline; `Shift+Enter` / `Alt+Enter` / `Ctrl+S` sends message (cross-platform WSL/macOS/modern terminal support) (partial close #2)
- Multi-line messages now render correctly in the message view — `\n` splits into separate lines
- Input box grows dynamically with content (min 1 line / max 6 lines)
- Version number shown in status bar

## Closes / Partially addresses

- Closes #5 — input box scrolling and text visibility
- Partially addresses #2:
  - ✅ Arrow key cursor navigation in input
  - ✅ Multi-line input (`Enter` = newline, `Ctrl+S` / `Shift+Enter` / `Alt+Enter` = send)
  - ✅ Multi-line message rendering in chat view
  - ✅ PageUp/PageDown scroll through message history
  - ❌ Not implemented: PageUp/PageDown/Home/End for chat list navigation
  - ❌ Not implemented: Home/End to jump to oldest/newest message in message view
  - ❌ Not implemented: Configurable send key via config file

## Test plan

- [ ] Type multi-line message with `Enter`, verify input box grows
- [ ] Use `Ctrl+S` to send on WSL — message appears in chat view
- [ ] Send message with `\n`, verify it renders with line breaks in chat
- [ ] Arrow keys / Home / End move cursor in input box
- [ ] `Ctrl+U` clears input
- [ ] `r` rename chat — Enter confirms, Shift+Enter blocked (no newline in name)
- [ ] Version shown in status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)