### PR TITLE
feat: chat search, unread sync, INSERT mode UX, chat highlight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,22 @@ permissions:
   contents: write
 
 jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Cargo.toml version matches CHANGELOG
+        run: |
+          CARGO_VER=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          if ! grep -q "## v$CARGO_VER" CHANGELOG.md; then
+            echo "ERROR: Cargo.toml version $CARGO_VER not found in CHANGELOG.md"
+            exit 1
+          fi
+          echo "OK: v$CARGO_VER found in CHANGELOG.md"
+
   version:
     runs-on: ubuntu-latest
+    needs: version-check
     outputs:
       tag: ${{ steps.compute.outputs.tag }}
       cargo_version: ${{ steps.compute.outputs.cargo_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Newsletter chats (`@newsletter` JIDs) now show a `[NL]` tag and are excluded from the unread count header
 - New messages are highlighted in yellow with a full-width `─── N new ───` separator when navigating to a chat
+- Reading messages on another device (phone/web) now clears the unread count and `─── N new ───` separator via `ReadSelf` receipts
+- Selected chat row now uses blue background with white text for clearer focus indication
+- Press `/` to open a fuzzy chat search popup — type to filter, top 5 results shown, `j`/`k` to navigate, `Enter` to jump to chat and enter insert mode, `Esc` to cancel
+- INSERT mode is now clearly indicated across the UI: mode pill badge in the status bar (`✏ INSERT` in yellow), centered label on the input box border, and the chat list header shows the current chat name
 
 ## v0.3.0 — 2026-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.1 — 2026-03-05
+
+- Newsletter chats (`@newsletter` JIDs) now show a `[NL]` tag and are excluded from the unread count header
+- New messages are highlighted in yellow with a full-width `─── N new ───` separator when navigating to a chat
+
 ## v0.3.0 — 2026-03-04
 
 ### Address Book Separation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "zero-drift-chat"
-version = "0.1.1"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zero-drift-chat"
-version = "0.2.1"
+version = "0.3.1"
 edition = "2021"
 
 [dependencies]

--- a/bump.sh
+++ b/bump.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Usage: ./bump.sh
+# Auto-increments the patch digit in Cargo.toml and adds a CHANGELOG.md entry.
+set -euo pipefail
+
+CURRENT=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+MINOR=$(echo "$CURRENT" | cut -d. -f2)
+PATCH=$(echo "$CURRENT" | cut -d. -f3)
+VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+echo "$CURRENT → $VERSION"
+
+DATE=$(date +%Y-%m-%d)
+
+# Update Cargo.toml
+sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+echo "Cargo.toml → $VERSION"
+
+# Prepend CHANGELOG entry
+ENTRY="## v$VERSION — $DATE\n\n- \n"
+sed -i "s/^# Changelog$/# Changelog\n\n$ENTRY/" CHANGELOG.md
+echo "CHANGELOG.md → v$VERSION entry added"
+
+echo "Done. Edit CHANGELOG.md to fill in the release note, then commit."

--- a/docs/plans/2026-03-05-chat-search-design.md
+++ b/docs/plans/2026-03-05-chat-search-design.md
@@ -1,0 +1,93 @@
+# Chat Search Design
+
+**Date:** 2026-03-05
+**Feature:** `/` shortcut to fuzzy-find chats by display name, Enter to navigate + enter insert mode
+
+## Overview
+
+Press `/` in Normal mode to open a fuzzy-search popup over the chat list. Type to filter; the overlay shows the top 5 matching chats. Press Enter to jump to the selected chat and enter Insert (Editing) mode. Press Esc to cancel.
+
+## Section 1 — State & Data Model
+
+New `InputMode::Searching` variant added to the existing enum.
+
+New struct on `AppState`:
+```rust
+pub struct SearchState {
+    pub query: String,
+    pub results: Vec<usize>,  // indices into state.chats (top 5)
+    pub selected: usize,      // currently highlighted result
+}
+```
+
+`AppState` gains `pub search_state: Option<SearchState>` — `None` when not active.
+
+**Fuzzy match algorithm:** all chars of `query` must appear in order (case-insensitive) in `display_name ?? name`. Results scored by match span compactness (smaller span = better). Top 5 returned. No new crate required.
+
+## Section 2 — Actions & Keybindings
+
+New `Action` variants:
+```rust
+OpenSearch,
+SearchInput(KeyEvent),
+SearchNext,
+SearchPrev,
+SearchConfirm,
+SearchClose,
+```
+
+- Normal mode: `'/'` → `OpenSearch`
+- New `map_search_mode`:
+  - `j` / `↓` → `SearchNext`
+  - `k` / `↑` → `SearchPrev`
+  - `Enter` → `SearchConfirm`
+  - `Esc` → `SearchClose`
+  - everything else → `SearchInput(key)`
+
+Status bar hint:
+```
+Type to filter | j/k:Navigate | Enter:Open+Insert | Esc:Cancel
+```
+
+## Section 3 — Overlay Widget
+
+New file: `src/tui/widgets/search_overlay.rs`
+
+Popup rendered over the chat list area:
+```
+┌─ Find Chat ──────────────────┐
+│ / query_text▌                │
+│──────────────────────────────│
+│ ▶ [WA] xin wei               │  ← selected (blue bg, white fg)
+│   [WA] wei ming              │
+│   [WA] xin xin               │
+└──────────────────────────────┘
+```
+
+- Width: full chat list panel width
+- Height: 2 (borders) + 1 (query line) + 1 (divider) + up to 5 results
+- Empty query → results area hidden
+- Highlight style matches existing chat selection (blue bg, white fg, bold)
+
+`render.rs` renders this overlay last (on top) when `input_mode == Searching`.
+
+## Section 4 — App Handler Logic
+
+- **`OpenSearch`** — `input_mode = Searching`, `search_state = Some(SearchState::default())`
+- **`SearchInput(key)`** — update `query` (backspace removes last char, printable appends), recompute top-5 results, clamp `selected`
+- **`SearchNext`/`SearchPrev`** — move `selected`, wrapping within results
+- **`SearchConfirm`** — if results non-empty: select chat, load messages, capture new message count, clear unread, send read receipts, set `input_mode = Editing`, clear search state, refresh title
+- **`SearchClose`** — clear search state, `input_mode = Normal`
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/tui/app_state.rs` | Add `InputMode::Searching`, `SearchState`, `search_state` field |
+| `src/tui/keybindings.rs` | Add 6 action variants, `'/'` in normal map, `map_search_mode` |
+| `src/tui/widgets/search_overlay.rs` | New file — popup widget |
+| `src/tui/widgets/mod.rs` | `pub mod search_overlay` |
+| `src/tui/render.rs` | Render search overlay when Searching |
+| `src/tui/widgets/status_bar.rs` | Add Searching hint |
+| `src/tui/widgets/input_bar.rs` | Add `InputMode::Searching` arm ("SEARCH" tag) |
+| `src/app.rs` | Handle 6 new actions |

--- a/docs/plans/2026-03-05-chat-search.md
+++ b/docs/plans/2026-03-05-chat-search.md
@@ -1,0 +1,617 @@
+# Chat Search Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Press `/` in Normal mode to open a fuzzy-search popup over the chat list; Enter navigates to the selected chat and enters Insert mode.
+
+**Architecture:** New `InputMode::Searching` follows the same pattern as `Renaming`/`ChatMenu` — state struct on `AppState`, action variants, keybinding map, overlay widget rendered last in `render.rs`. Fuzzy match lives in its own module (`src/tui/search.rs`) so it can be unit-tested in isolation.
+
+**Tech Stack:** Rust, ratatui (widgets: `List`, `Block`, `Paragraph`, `Clear`), crossterm KeyEvent, existing `UnifiedChat` type.
+
+---
+
+### Task 1: Fuzzy match module with unit tests
+
+**Files:**
+- Create: `src/tui/search.rs`
+- Modify: `src/tui/mod.rs` (add `pub mod search;`)
+
+**Step 1: Create `src/tui/search.rs` with the functions and tests**
+
+```rust
+use crate::core::types::UnifiedChat;
+
+/// Returns the match span length (lower = tighter match = better).
+/// All chars of `query` must appear in order in `text` (case-insensitive).
+/// Returns None if no match.
+pub fn fuzzy_score(query: &str, text: &str) -> Option<usize> {
+    if query.is_empty() {
+        return Some(0);
+    }
+    let query_chars: Vec<char> = query.to_lowercase().chars().collect();
+    let text_chars: Vec<char> = text.to_lowercase().chars().collect();
+    let mut qi = 0;
+    let mut first_match: Option<usize> = None;
+    let mut last_match = 0;
+    for (ti, &tc) in text_chars.iter().enumerate() {
+        if tc == query_chars[qi] {
+            if first_match.is_none() {
+                first_match = Some(ti);
+            }
+            last_match = ti;
+            qi += 1;
+            if qi == query_chars.len() {
+                return Some(last_match - first_match.unwrap());
+            }
+        }
+    }
+    None
+}
+
+/// Returns up to `limit` chat indices from `chats`, sorted by fuzzy score (best first).
+/// Returns empty vec when query is empty.
+pub fn top_fuzzy_matches(query: &str, chats: &[UnifiedChat], limit: usize) -> Vec<usize> {
+    if query.is_empty() {
+        return vec![];
+    }
+    let mut scored: Vec<(usize, usize)> = chats
+        .iter()
+        .enumerate()
+        .filter_map(|(i, c)| {
+            let name = c.display_name.as_deref().unwrap_or(&c.name);
+            fuzzy_score(query, name).map(|s| (i, s))
+        })
+        .collect();
+    scored.sort_by_key(|&(_, s)| s);
+    scored.into_iter().take(limit).map(|(i, _)| i).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fuzzy_score_exact() {
+        assert_eq!(fuzzy_score("xin", "xin wei"), Some(2));
+    }
+
+    #[test]
+    fn test_fuzzy_score_scattered() {
+        // 'x' at 0, 'w' at 4 → span 4
+        assert_eq!(fuzzy_score("xw", "xin wei"), Some(4));
+    }
+
+    #[test]
+    fn test_fuzzy_score_no_match() {
+        assert_eq!(fuzzy_score("zzz", "xin wei"), None);
+    }
+
+    #[test]
+    fn test_fuzzy_score_empty_query() {
+        assert_eq!(fuzzy_score("", "anything"), Some(0));
+    }
+
+    #[test]
+    fn test_fuzzy_score_case_insensitive() {
+        assert_eq!(fuzzy_score("XIN", "xin wei"), Some(2));
+    }
+
+    #[test]
+    fn test_top_fuzzy_matches_empty_query() {
+        let chats = vec![make_chat("alice"), make_chat("bob")];
+        assert!(top_fuzzy_matches("", &chats, 5).is_empty());
+    }
+
+    #[test]
+    fn test_top_fuzzy_matches_limit() {
+        let chats = vec![
+            make_chat("alice"),
+            make_chat("alan"),
+            make_chat("alex"),
+            make_chat("albert"),
+            make_chat("alvin"),
+            make_chat("aldous"),
+        ];
+        let results = top_fuzzy_matches("al", &chats, 5);
+        assert_eq!(results.len(), 5);
+    }
+
+    #[test]
+    fn test_top_fuzzy_matches_sorted_by_score() {
+        // "xin" scores 2 on "xin wei", higher span on "xi_n_long"
+        let chats = vec![make_chat("xi_n_long"), make_chat("xin wei")];
+        let results = top_fuzzy_matches("xin", &chats, 5);
+        // "xin wei" (index 1) should rank first (tighter match)
+        assert_eq!(results[0], 1);
+    }
+
+    fn make_chat(name: &str) -> UnifiedChat {
+        UnifiedChat {
+            id: name.to_string(),
+            name: name.to_string(),
+            display_name: None,
+            platform: crate::core::types::Platform::Mock,
+            last_message: None,
+            last_message_time: None,
+            unread_count: 0,
+            is_pinned: false,
+            is_newsletter: false,
+        }
+    }
+}
+```
+
+**Step 2: Add `pub mod search;` to `src/tui/mod.rs`**
+
+The file currently lists modules like `pub mod app_state;`. Add `pub mod search;` to the list.
+
+**Step 3: Run tests**
+
+```bash
+cargo test tui::search
+```
+
+Expected: all 8 tests pass.
+
+**Step 4: Commit**
+
+```bash
+git add src/tui/search.rs src/tui/mod.rs
+git commit -m "feat: add fuzzy chat search module with unit tests"
+```
+
+---
+
+### Task 2: State types — `InputMode::Searching` and `SearchState`
+
+**Files:**
+- Modify: `src/tui/app_state.rs`
+
+**Step 1: Add `Searching` to `InputMode` enum**
+
+In `app_state.rs`, the enum currently ends with `ChatMenu`. Add `Searching`:
+
+```rust
+pub enum InputMode {
+    Normal,
+    Editing,
+    Settings,
+    Renaming,
+    ChatMenu,
+    Searching,
+}
+```
+
+**Step 2: Add `SearchState` struct above `AppState`**
+
+```rust
+pub struct SearchState {
+    pub query: String,
+    pub results: Vec<usize>,  // indices into AppState::chats (top 5)
+    pub selected: usize,      // currently highlighted result index
+}
+
+impl SearchState {
+    pub fn new() -> Self {
+        Self { query: String::new(), results: vec![], selected: 0 }
+    }
+}
+```
+
+**Step 3: Add `search_state` field to `AppState`**
+
+In the `AppState` struct, after `chat_menu_state`:
+```rust
+pub search_state: Option<SearchState>,
+```
+
+In `AppState::new()`, initialise it:
+```rust
+search_state: None,
+```
+
+**Step 4: Build — compiler will show every match that needs a new arm**
+
+```bash
+cargo build 2>&1 | grep "error"
+```
+
+Expected: errors on `input_bar.rs` and `status_bar.rs` match arms — note them, fix in Task 4.
+
+**Step 5: Commit**
+
+```bash
+git add src/tui/app_state.rs
+git commit -m "feat: add InputMode::Searching and SearchState"
+```
+
+---
+
+### Task 3: Actions and keybindings
+
+**Files:**
+- Modify: `src/tui/keybindings.rs`
+
+**Step 1: Add new `Action` variants**
+
+In the `Action` enum, after `ChatMenuClose`:
+```rust
+OpenSearch,
+SearchInput(KeyEvent),
+SearchNext,
+SearchPrev,
+SearchConfirm,
+SearchClose,
+```
+
+**Step 2: Wire `'/'` in `map_normal_mode`**
+
+In `map_normal_mode`, after the `'x'` arm:
+```rust
+KeyCode::Char('/') => Action::OpenSearch,
+```
+
+**Step 3: Add `map_search_mode` function**
+
+At the bottom of the file:
+```rust
+fn map_search_mode(key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Esc => Action::SearchClose,
+        KeyCode::Enter => Action::SearchConfirm,
+        KeyCode::Char('j') | KeyCode::Down => Action::SearchNext,
+        KeyCode::Char('k') | KeyCode::Up => Action::SearchPrev,
+        _ => Action::SearchInput(key),
+    }
+}
+```
+
+**Step 4: Add arm to `map_key`**
+
+In `map_key`, after `InputMode::ChatMenu`:
+```rust
+InputMode::Searching => map_search_mode(key),
+```
+
+**Step 5: Build**
+
+```bash
+cargo build 2>&1 | grep "error"
+```
+
+Expected: only errors from `input_bar`/`status_bar` non-exhaustive matches.
+
+**Step 6: Commit**
+
+```bash
+git add src/tui/keybindings.rs
+git commit -m "feat: add search actions and keybindings"
+```
+
+---
+
+### Task 4: Update `input_bar` and `status_bar`
+
+**Files:**
+- Modify: `src/tui/widgets/input_bar.rs`
+- Modify: `src/tui/widgets/status_bar.rs`
+
+**Step 1: Add `Searching` arm to `input_bar.rs`**
+
+In the `match mode` block for `(mode_tag, border_color)`:
+```rust
+InputMode::Searching => ("SEARCH", Color::Blue),
+```
+
+**Step 2: Add `Searching` arm to `status_bar.rs`**
+
+In the `match mode` block for `hints`:
+```rust
+InputMode::Searching => "Type to filter | j/k:Navigate | Enter:Open+Insert | Esc:Cancel",
+```
+
+**Step 3: Build — should be clean now**
+
+```bash
+cargo build 2>&1 | grep "error"
+```
+
+Expected: no errors.
+
+**Step 4: Commit**
+
+```bash
+git add src/tui/widgets/input_bar.rs src/tui/widgets/status_bar.rs
+git commit -m "feat: add Searching mode to input_bar and status_bar"
+```
+
+---
+
+### Task 5: Search overlay widget
+
+**Files:**
+- Create: `src/tui/widgets/search_overlay.rs`
+- Modify: `src/tui/widgets/mod.rs`
+- Modify: `src/tui/render.rs`
+
+**Step 1: Create `src/tui/widgets/search_overlay.rs`**
+
+```rust
+use ratatui::{
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
+    Frame,
+};
+
+use crate::core::types::UnifiedChat;
+use crate::tui::app_state::SearchState;
+
+pub fn render_search_overlay(
+    f: &mut Frame,
+    chat_list_area: Rect,
+    state: &SearchState,
+    chats: &[UnifiedChat],
+) {
+    let result_count = state.results.len().min(5);
+    // 2 borders + 1 query line + (1 divider + N results) if any results
+    let inner_height = 1 + if result_count > 0 { 1 + result_count } else { 0 };
+    let height = (2 + inner_height as u16).min(chat_list_area.height);
+
+    let popup_area = Rect {
+        x: chat_list_area.x,
+        y: chat_list_area.y,
+        width: chat_list_area.width,
+        height,
+    };
+
+    f.render_widget(Clear, popup_area);
+
+    let block = Block::default()
+        .title(" Find Chat ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Blue));
+    let inner = block.inner(popup_area);
+    f.render_widget(block, popup_area);
+
+    // Query line
+    let query_area = Rect { x: inner.x, y: inner.y, width: inner.width, height: 1 };
+    f.render_widget(
+        Paragraph::new(format!("/ {}▌", state.query))
+            .style(Style::default().fg(Color::White)),
+        query_area,
+    );
+
+    if result_count == 0 {
+        return;
+    }
+
+    // Divider
+    let sep_area = Rect { x: inner.x, y: inner.y + 1, width: inner.width, height: 1 };
+    f.render_widget(
+        Paragraph::new("─".repeat(inner.width as usize))
+            .style(Style::default().fg(Color::DarkGray)),
+        sep_area,
+    );
+
+    // Results list
+    let results_area = Rect {
+        x: inner.x,
+        y: inner.y + 2,
+        width: inner.width,
+        height: result_count as u16,
+    };
+
+    let highlight = Style::default()
+        .bg(Color::Blue)
+        .fg(Color::White)
+        .add_modifier(Modifier::BOLD);
+
+    let items: Vec<ListItem> = state
+        .results
+        .iter()
+        .enumerate()
+        .map(|(pos, &idx)| {
+            let chat = &chats[idx];
+            let name = chat.display_name.as_deref().unwrap_or(&chat.name);
+            let selector = if pos == state.selected { "▶ " } else { "  " };
+            let tag = format!("[{}] ", chat.platform);
+            ListItem::new(Line::from(vec![
+                Span::raw(selector),
+                Span::styled(tag, Style::default().fg(Color::DarkGray)),
+                Span::styled(name.to_string(), Style::default().fg(Color::White)),
+            ]))
+        })
+        .collect();
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(state.selected));
+    f.render_stateful_widget(List::new(items).highlight_style(highlight), results_area, &mut list_state);
+}
+```
+
+**Step 2: Add `pub mod search_overlay;` to `src/tui/widgets/mod.rs`**
+
+Append to the existing module list.
+
+**Step 3: Add render call to `src/tui/render.rs`**
+
+After the ChatMenu overlay block (at the bottom of `draw`), add:
+```rust
+// Render search overlay on top if active
+if state.input_mode == InputMode::Searching {
+    if let Some(ref search) = state.search_state {
+        widgets::search_overlay::render_search_overlay(f, chat_list_area, search, &state.chats);
+    }
+}
+```
+
+Also add `search_overlay` to the import in `render.rs`:
+```rust
+use super::widgets::{self, chat_list, input_bar, message_view, qr_overlay, search_overlay, settings_overlay, status_bar};
+```
+
+Actually, since we call it via `widgets::search_overlay::render_search_overlay`, the `use` import just needs `widgets` in scope which it already has. No change needed to the import line.
+
+**Step 4: Build**
+
+```bash
+cargo build 2>&1 | grep "error"
+```
+
+Expected: no errors.
+
+**Step 5: Commit**
+
+```bash
+git add src/tui/widgets/search_overlay.rs src/tui/widgets/mod.rs src/tui/render.rs
+git commit -m "feat: add search overlay widget"
+```
+
+---
+
+### Task 6: Handle search actions in `app.rs`
+
+**Files:**
+- Modify: `src/app.rs`
+
+**Step 1: Add import for `top_fuzzy_matches` and `SearchState`**
+
+At the top of `src/app.rs`, the existing import line for app_state is:
+```rust
+use crate::tui::app_state::{AppState, ChatMenuItem, InputMode, SettingsKey, SettingsValue};
+```
+
+Add `SearchState` to that list:
+```rust
+use crate::tui::app_state::{AppState, ChatMenuItem, InputMode, SearchState, SettingsKey, SettingsValue};
+```
+
+Add the search module import (near the other `crate::tui` imports):
+```rust
+use crate::tui::search::top_fuzzy_matches;
+```
+
+**Step 2: Add `OpenSearch` arm in `handle_action`**
+
+Find where `Action::OpenChatMenu` is handled. Add a new arm nearby:
+```rust
+Action::OpenSearch => {
+    self.state.search_state = Some(SearchState::new());
+    self.state.input_mode = InputMode::Searching;
+}
+```
+
+**Step 3: Add `SearchClose` arm**
+
+```rust
+Action::SearchClose => {
+    self.state.search_state = None;
+    self.state.input_mode = InputMode::Normal;
+}
+```
+
+**Step 4: Add `SearchInput` arm**
+
+```rust
+Action::SearchInput(key) => {
+    use crossterm::event::KeyCode;
+    if let Some(ref mut ss) = self.state.search_state {
+        match key.code {
+            KeyCode::Backspace => { ss.query.pop(); }
+            KeyCode::Char(c) => { ss.query.push(c); }
+            _ => {}
+        }
+        ss.results = top_fuzzy_matches(&ss.query, &self.state.chats, 5);
+        ss.selected = ss.selected.min(ss.results.len().saturating_sub(1));
+    }
+}
+```
+
+**Step 5: Add `SearchNext` and `SearchPrev` arms**
+
+```rust
+Action::SearchNext => {
+    if let Some(ref mut ss) = self.state.search_state {
+        if !ss.results.is_empty() {
+            ss.selected = (ss.selected + 1) % ss.results.len();
+        }
+    }
+}
+Action::SearchPrev => {
+    if let Some(ref mut ss) = self.state.search_state {
+        if !ss.results.is_empty() {
+            ss.selected = ss.selected.checked_sub(1).unwrap_or(ss.results.len() - 1);
+        }
+    }
+}
+```
+
+**Step 6: Add `SearchConfirm` arm**
+
+```rust
+Action::SearchConfirm => {
+    let chat_idx = self.state.search_state.as_ref()
+        .and_then(|ss| ss.results.get(ss.selected).copied());
+    if let Some(idx) = chat_idx {
+        self.state.search_state = None;
+        self.state.input_mode = InputMode::Editing;
+        self.state.chat_list_state.select(Some(idx));
+        self.load_selected_chat_messages();
+        self.capture_new_message_count();
+        self.clear_selected_unread();
+        self.send_read_receipts().await;
+        self.refresh_title();
+    }
+}
+```
+
+**Step 7: Full build**
+
+```bash
+cargo build 2>&1 | grep "error"
+```
+
+Expected: no errors, only existing warnings.
+
+**Step 8: Run all tests**
+
+```bash
+cargo test
+```
+
+Expected: all tests pass including the 8 fuzzy match tests.
+
+**Step 9: Commit**
+
+```bash
+git add src/app.rs
+git commit -m "feat: handle search actions — open, input, navigate, confirm, close"
+```
+
+---
+
+### Task 7: Install and verify
+
+**Step 1: Install**
+
+```bash
+cargo install --path .
+```
+
+**Step 2: Manual verification**
+
+1. Run `zero-drift-chat`
+2. Press `/` → popup appears with `Find Chat` border, query line shows `/ ▌`, status bar shows search hints
+3. Type part of a chat name → up to 5 fuzzy results appear below the divider
+4. Press `j`/`k` → `▶` selector moves between results
+5. Press `Enter` → chat list jumps to that chat, insert mode activates (input bar shows `[INSERT]`)
+6. Press `/` again, then `Esc` → popup closes, back to Normal mode
+
+**Step 3: Final commit**
+
+```bash
+git add -u
+git commit -m "chore: verify chat search feature complete"
+```

--- a/src/app.rs
+++ b/src/app.rs
@@ -556,7 +556,7 @@ impl App {
                     .and_then(|ss| ss.results.get(ss.selected).copied());
                 if let Some(idx) = chat_idx {
                     self.state.search_state = None;
-                    self.state.input_mode = InputMode::Editing;
+                    self.state.enter_editing();
                     self.state.chat_list_state.select(Some(idx));
                     self.load_selected_chat_messages();
                     self.capture_new_message_count();

--- a/src/app.rs
+++ b/src/app.rs
@@ -323,6 +323,7 @@ impl App {
             Action::NextChat => {
                 self.state.select_next_chat();
                 self.load_selected_chat_messages();
+                self.capture_new_message_count();
                 self.clear_selected_unread();
                 self.send_read_receipts().await;
                 self.refresh_title();
@@ -330,6 +331,7 @@ impl App {
             Action::PrevChat => {
                 self.state.select_prev_chat();
                 self.load_selected_chat_messages();
+                self.capture_new_message_count();
                 self.clear_selected_unread();
                 self.send_read_receipts().await;
                 self.refresh_title();
@@ -547,6 +549,16 @@ impl App {
                 tracing::error!("Failed to send read receipts: {}", e);
             }
         }
+    }
+
+    fn capture_new_message_count(&mut self) {
+        self.state.new_message_count = self
+            .state
+            .chat_list_state
+            .selected()
+            .and_then(|i| self.state.chats.get(i))
+            .map(|c| c.unread_count as usize)
+            .unwrap_or(0);
     }
 
     fn clear_selected_unread(&mut self) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,10 +16,11 @@ use crate::providers::whatsapp::WhatsAppProvider;
 use crate::storage::{AddressBook, Database};
 use tui_textarea::TextArea;
 
-use crate::tui::app_state::{AppState, ChatMenuItem, InputMode, SettingsKey, SettingsValue};
+use crate::tui::app_state::{AppState, ChatMenuItem, InputMode, SearchState, SettingsKey, SettingsValue};
 use crate::tui::event::{AppEvent, EventHandler};
 use crate::tui::keybindings::{map_key, Action};
 use crate::tui::render;
+use crate::tui::search::top_fuzzy_matches;
 use crate::tui;
 
 pub struct App {
@@ -303,6 +304,18 @@ impl App {
                     tracing::info!("QR code received for WhatsApp pairing");
                     self.state.qr_code = Some(code);
                 }
+                ProviderEvent::SelfRead { chat_id } => {
+                    if let Some(chat) = self.state.chats.iter_mut().find(|c| c.id == chat_id) {
+                        if chat.unread_count > 0 {
+                            chat.unread_count = 0;
+                            let _ = self.db.update_unread_count(&chat.id, 0);
+                        }
+                    }
+                    if self.state.selected_chat_id().map(|id| id == chat_id).unwrap_or(false) {
+                        self.state.new_message_count = 0;
+                    }
+                    self.refresh_title();
+                }
                 ProviderEvent::SyncCompleted => {
                     tracing::info!("Sync completed, refreshing current chat");
                     self.load_selected_chat_messages();
@@ -503,6 +516,54 @@ impl App {
             }
             Action::ChatMenuClose => {
                 self.state.close_chat_menu();
+            }
+            Action::OpenSearch => {
+                self.state.search_state = Some(SearchState::new());
+                self.state.input_mode = InputMode::Searching;
+            }
+            Action::SearchClose => {
+                self.state.search_state = None;
+                self.state.input_mode = InputMode::Normal;
+            }
+            Action::SearchInput(key) => {
+                use crossterm::event::KeyCode;
+                if let Some(ref mut ss) = self.state.search_state {
+                    match key.code {
+                        KeyCode::Backspace => { ss.query.pop(); }
+                        KeyCode::Char(c) => { ss.query.push(c); }
+                        _ => {}
+                    }
+                    ss.results = top_fuzzy_matches(&ss.query, &self.state.chats, 5);
+                    ss.selected = ss.selected.min(ss.results.len().saturating_sub(1));
+                }
+            }
+            Action::SearchNext => {
+                if let Some(ref mut ss) = self.state.search_state {
+                    if !ss.results.is_empty() {
+                        ss.selected = (ss.selected + 1) % ss.results.len();
+                    }
+                }
+            }
+            Action::SearchPrev => {
+                if let Some(ref mut ss) = self.state.search_state {
+                    if !ss.results.is_empty() {
+                        ss.selected = ss.selected.checked_sub(1).unwrap_or(ss.results.len() - 1);
+                    }
+                }
+            }
+            Action::SearchConfirm => {
+                let chat_idx = self.state.search_state.as_ref()
+                    .and_then(|ss| ss.results.get(ss.selected).copied());
+                if let Some(idx) = chat_idx {
+                    self.state.search_state = None;
+                    self.state.input_mode = InputMode::Editing;
+                    self.state.chat_list_state.select(Some(idx));
+                    self.load_selected_chat_messages();
+                    self.capture_new_message_count();
+                    self.clear_selected_unread();
+                    self.send_read_receipts().await;
+                    self.refresh_title();
+                }
             }
             Action::None => {}
         }

--- a/src/core/provider.rs
+++ b/src/core/provider.rs
@@ -15,6 +15,7 @@ pub enum ProviderEvent {
     AuthStatusChanged(Platform, AuthStatus),
     AuthQrCode(String),
     SyncCompleted,
+    SelfRead { chat_id: String },
 }
 
 #[async_trait]

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -88,4 +88,5 @@ pub struct UnifiedChat {
     pub unread_count: u32,
     pub is_group: bool,
     pub is_pinned: bool,
+    pub is_newsletter: bool,
 }

--- a/src/providers/mock/mod.rs
+++ b/src/providers/mock/mod.rs
@@ -15,11 +15,14 @@ const CHAT_NAMES: &[&str] = &[
     "Bob Smith",
     "Team Standup",
     "Eve Martinez",
-    "Charlie & Dave",
+    "Tech Weekly",
     "Project Alpha",
     "Mom",
     "Jane Doe",
 ];
+
+/// Indices into CHAT_NAMES that are newsletters
+const NEWSLETTER_INDICES: &[usize] = &[4]; // "Tech Weekly"
 
 const MOCK_MESSAGES: &[&str] = &[
     "Hey, how's it going?",
@@ -33,7 +36,7 @@ const MOCK_MESSAGES: &[&str] = &[
     "I'll send you the details",
     "Thanks for the help!",
     "Running a bit late",
-    "Check out this article I found",
+    "Check out this article I found: https://example.com/article",
     "Good morning everyone!",
     "The build is green now",
     "Happy Friday!",
@@ -77,8 +80,9 @@ impl MockProvider {
                 display_name: None,
                 last_message: None,
                 unread_count: 0,
-                is_group: i == 2 || i == 4, // "Team Standup" and "Charlie & Dave"
+                is_group: i == 2, // "Team Standup"
                 is_pinned: false,
+                is_newsletter: NEWSLETTER_INDICES.contains(&i),
             })
             .collect()
     }

--- a/src/providers/whatsapp/mod.rs
+++ b/src/providers/whatsapp/mod.rs
@@ -289,6 +289,10 @@ fn handle_wa_event(
                     status,
                 });
             }
+            if type_str == "ReadSelf" {
+                let chat_id = jid_to_chat_id(&receipt.source.chat, jid_cache);
+                let _ = tx.send(ProviderEvent::SelfRead { chat_id });
+            }
         }
         Event::JoinedGroup(lazy_conv) => {
             if let Some(conv) = lazy_conv.get() {

--- a/src/providers/whatsapp/mod.rs
+++ b/src/providers/whatsapp/mod.rs
@@ -242,13 +242,15 @@ fn handle_wa_event(
                 source.is_group,
                 jid_cache,
             ) {
+                let chat_jid_str = source.chat.to_string();
+                let is_newsletter = chat_jid_str.contains("@newsletter");
                 let chat_id = jid_to_chat_id(&source.chat, jid_cache);
 
                 // Determine chat name:
-                // - Groups: never use sender's push_name (that's a person, not the group)
+                // - Groups/newsletters: never use sender's push_name (that's a person, not the group)
                 // - 1:1 incoming: use push_name if available
                 // - Outgoing / fallback: use phone number from JID
-                let chat_name = if source.is_group {
+                let chat_name = if source.is_group || is_newsletter {
                     jid_to_display_name(&source.chat)
                 } else if source.is_from_me {
                     jid_to_display_name(&source.chat)
@@ -268,6 +270,7 @@ fn handle_wa_event(
                     unread_count: if unified.is_outgoing { 0 } else { 1 },
                     is_group: source.is_group,
                     is_pinned: false,
+                    is_newsletter,
                 };
 
                 let _ = tx.send(ProviderEvent::ChatsUpdated(vec![chat]));
@@ -308,6 +311,7 @@ fn handle_wa_event(
                 if let Ok(jid) = jid_str.parse::<Jid>() {
                     let chat_id = jid_to_chat_id(&jid, jid_cache);
                     let is_group = jid_str.contains("@g.us");
+                    let is_newsletter = jid_str.contains("@newsletter");
 
                     let name = if is_group {
                         conv.name
@@ -341,6 +345,7 @@ fn handle_wa_event(
                         unread_count: conv.unread_count.unwrap_or(0),
                         is_group,
                         is_pinned: false,
+                        is_newsletter,
                     };
 
                     let _ = tx.send(ProviderEvent::ChatsUpdated(vec![chat]));

--- a/src/storage/chats.rs
+++ b/src/storage/chats.rs
@@ -8,14 +8,15 @@ impl Database {
         // Use INSERT ON CONFLICT to preserve user-set display_name
         // Note: pinned column is intentionally excluded — managed via set_chat_pinned()
         self.conn.execute(
-            "INSERT INTO chats (id, platform, name, last_message, unread_count, is_group, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'))
+            "INSERT INTO chats (id, platform, name, last_message, unread_count, is_group, is_newsletter, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, datetime('now'))
              ON CONFLICT(id) DO UPDATE SET
                platform = excluded.platform,
                name = excluded.name,
                last_message = COALESCE(excluded.last_message, chats.last_message),
                unread_count = excluded.unread_count,
                is_group = excluded.is_group,
+               is_newsletter = excluded.is_newsletter,
                updated_at = datetime('now')",
             rusqlite::params![
                 chat.id,
@@ -24,6 +25,7 @@ impl Database {
                 chat.last_message,
                 chat.unread_count,
                 chat.is_group as i32,
+                chat.is_newsletter as i32,
             ],
         )?;
         Ok(())
@@ -31,7 +33,7 @@ impl Database {
 
     pub fn get_all_chats(&self) -> Result<Vec<UnifiedChat>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, platform, name, last_message, unread_count, is_group, display_name, pinned
+            "SELECT id, platform, name, last_message, unread_count, is_group, display_name, pinned, is_newsletter
              FROM chats ORDER BY pinned DESC, updated_at DESC",
         )?;
 
@@ -45,14 +47,15 @@ impl Database {
                 let is_group: i32 = row.get(5)?;
                 let display_name: Option<String> = row.get(6)?;
                 let pinned: i32 = row.get(7)?;
+                let is_newsletter: i32 = row.get(8)?;
 
-                Ok((id, platform_str, name, last_message, unread_count, is_group, display_name, pinned))
+                Ok((id, platform_str, name, last_message, unread_count, is_group, display_name, pinned, is_newsletter))
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
         let result = chats
             .into_iter()
-            .map(|(id, platform_str, name, last_message, unread_count, is_group, display_name, pinned)| {
+            .map(|(id, platform_str, name, last_message, unread_count, is_group, display_name, pinned, is_newsletter)| {
                 let platform = match platform_str.as_str() {
                     "WhatsApp" => Platform::WhatsApp,
                     "Telegram" => Platform::Telegram,
@@ -68,6 +71,7 @@ impl Database {
                     unread_count,
                     is_group: is_group != 0,
                     is_pinned: pinned != 0,
+                    is_newsletter: is_newsletter != 0,
                 }
             })
             .collect();

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -80,6 +80,17 @@ impl Database {
             .conn
             .execute("ALTER TABLE chats ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0", []);
 
+        // Migration: add is_newsletter column if not exists
+        let _ = self
+            .conn
+            .execute("ALTER TABLE chats ADD COLUMN is_newsletter INTEGER NOT NULL DEFAULT 0", []);
+
+        // Backfill is_newsletter for chats already in DB whose id contains @newsletter
+        let _ = self.conn.execute(
+            "UPDATE chats SET is_newsletter = 1 WHERE id LIKE '%@newsletter%' AND is_newsletter = 0",
+            [],
+        );
+
         Ok(())
     }
 }

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -11,6 +11,7 @@ pub enum InputMode {
     Settings,
     Renaming,
     ChatMenu,
+    Searching,
 }
 
 // --- Settings overlay types ---
@@ -176,6 +177,18 @@ impl ChatMenuState {
     }
 }
 
+pub struct SearchState {
+    pub query: String,
+    pub results: Vec<usize>,  // indices into AppState::chats (top 5)
+    pub selected: usize,      // currently highlighted result index
+}
+
+impl SearchState {
+    pub fn new() -> Self {
+        Self { query: String::new(), results: vec![], selected: 0 }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActivePanel {
     ChatList,
@@ -196,6 +209,7 @@ pub struct AppState {
     pub mock_enabled: bool,
     pub settings_state: Option<SettingsState>,
     pub chat_menu_state: Option<ChatMenuState>,
+    pub search_state: Option<SearchState>,
     pub enter_sends: bool,
     /// Number of unread messages at the tail of `messages` when a chat was opened.
     pub new_message_count: usize,
@@ -220,6 +234,7 @@ impl AppState {
             mock_enabled: false,
             settings_state: None,
             chat_menu_state: None,
+            search_state: None,
             enter_sends: true,
             new_message_count: 0,
         }

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -197,6 +197,8 @@ pub struct AppState {
     pub settings_state: Option<SettingsState>,
     pub chat_menu_state: Option<ChatMenuState>,
     pub enter_sends: bool,
+    /// Number of unread messages at the tail of `messages` when a chat was opened.
+    pub new_message_count: usize,
 }
 
 impl AppState {
@@ -219,6 +221,7 @@ impl AppState {
             settings_state: None,
             chat_menu_state: None,
             enter_sends: true,
+            new_message_count: 0,
         }
     }
 

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -177,6 +177,7 @@ impl ChatMenuState {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct SearchState {
     pub query: String,
     pub results: Vec<usize>,  // indices into AppState::chats (top 5)

--- a/src/tui/keybindings.rs
+++ b/src/tui/keybindings.rs
@@ -39,6 +39,7 @@ pub fn map_key(key: KeyEvent, mode: InputMode, enter_sends: bool) -> Action {
         InputMode::Settings => map_settings_mode(key),
         InputMode::Renaming => map_renaming_mode(key),
         InputMode::ChatMenu => map_chat_menu_mode(key),
+        InputMode::Searching => Action::None,
     }
 }
 

--- a/src/tui/keybindings.rs
+++ b/src/tui/keybindings.rs
@@ -29,6 +29,12 @@ pub enum Action {
     ChatMenuPrev,
     ChatMenuConfirm,
     ChatMenuClose,
+    OpenSearch,
+    SearchInput(KeyEvent),
+    SearchNext,
+    SearchPrev,
+    SearchConfirm,
+    SearchClose,
     None,
 }
 
@@ -39,7 +45,7 @@ pub fn map_key(key: KeyEvent, mode: InputMode, enter_sends: bool) -> Action {
         InputMode::Settings => map_settings_mode(key),
         InputMode::Renaming => map_renaming_mode(key),
         InputMode::ChatMenu => map_chat_menu_mode(key),
-        InputMode::Searching => Action::None,
+        InputMode::Searching => map_search_mode(key),
     }
 }
 
@@ -54,6 +60,7 @@ fn map_normal_mode(key: KeyEvent) -> Action {
         KeyCode::Char('s') => Action::OpenSettings,
         KeyCode::Char('r') => Action::RenameChat,
         KeyCode::Char('x') => Action::OpenChatMenu,
+        KeyCode::Char('/') => Action::OpenSearch,
         KeyCode::PageUp => Action::ScrollUp,
         KeyCode::PageDown => Action::ScrollDown,
         _ => Action::None,
@@ -107,6 +114,16 @@ fn map_chat_menu_mode(key: KeyEvent) -> Action {
         KeyCode::Enter | KeyCode::Char('p') => Action::ChatMenuConfirm,
         KeyCode::Esc | KeyCode::Char('q') => Action::ChatMenuClose,
         _ => Action::None,
+    }
+}
+
+fn map_search_mode(key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Esc => Action::SearchClose,
+        KeyCode::Enter => Action::SearchConfirm,
+        KeyCode::Char('j') | KeyCode::Down => Action::SearchNext,
+        KeyCode::Char('k') | KeyCode::Up => Action::SearchPrev,
+        _ => Action::SearchInput(key),
     }
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,4 +1,5 @@
 pub mod app_state;
+pub mod search;
 pub mod event;
 pub mod keybindings;
 pub mod osc8;

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -91,4 +91,11 @@ pub fn draw(f: &mut Frame, state: &mut AppState) {
             widgets::chat_menu::render_chat_menu(f, chat_list_area, menu_state);
         }
     }
+
+    // Render search overlay on top if active
+    if state.input_mode == InputMode::Searching {
+        if let Some(ref search) = state.search_state {
+            widgets::search_overlay::render_search_overlay(f, chat_list_area, search, &state.chats);
+        }
+    }
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -47,6 +47,7 @@ pub fn draw(f: &mut Frame, state: &mut AppState) {
         &state.chats,
         &mut state.chat_list_state,
         state.active_panel,
+        state.input_mode,
     );
 
     message_view::render_message_view(

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -56,6 +56,7 @@ pub fn draw(f: &mut Frame, state: &mut AppState) {
         chat_name,
         state.scroll_offset,
         state.active_panel,
+        state.new_message_count,
     );
 
     input_bar::render_input_bar(

--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -1,0 +1,120 @@
+use crate::core::types::UnifiedChat;
+
+/// Returns the match span length (lower = tighter match = better).
+/// All chars of `query` must appear in order in `text` (case-insensitive).
+/// Returns None if no match.
+pub fn fuzzy_score(query: &str, text: &str) -> Option<usize> {
+    if query.is_empty() {
+        return Some(0);
+    }
+    let query_chars: Vec<char> = query.to_lowercase().chars().collect();
+    let text_chars: Vec<char> = text.to_lowercase().chars().collect();
+    let mut qi = 0;
+    let mut first_match: Option<usize> = None;
+    let mut last_match = 0;
+    for (ti, &tc) in text_chars.iter().enumerate() {
+        if tc == query_chars[qi] {
+            if first_match.is_none() {
+                first_match = Some(ti);
+            }
+            last_match = ti;
+            qi += 1;
+            if qi == query_chars.len() {
+                return Some(last_match - first_match.unwrap());
+            }
+        }
+    }
+    None
+}
+
+/// Returns up to `limit` chat indices from `chats`, sorted by fuzzy score (best first).
+/// Returns empty vec when query is empty.
+pub fn top_fuzzy_matches(query: &str, chats: &[UnifiedChat], limit: usize) -> Vec<usize> {
+    if query.is_empty() {
+        return vec![];
+    }
+    let mut scored: Vec<(usize, usize)> = chats
+        .iter()
+        .enumerate()
+        .filter_map(|(i, c)| {
+            let name = c.display_name.as_deref().unwrap_or(&c.name);
+            fuzzy_score(query, name).map(|s| (i, s))
+        })
+        .collect();
+    scored.sort_by_key(|&(_, s)| s);
+    scored.into_iter().take(limit).map(|(i, _)| i).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fuzzy_score_exact() {
+        assert_eq!(fuzzy_score("xin", "xin wei"), Some(2));
+    }
+
+    #[test]
+    fn test_fuzzy_score_scattered() {
+        // 'x' at 0, 'w' at 4 → span 4
+        assert_eq!(fuzzy_score("xw", "xin wei"), Some(4));
+    }
+
+    #[test]
+    fn test_fuzzy_score_no_match() {
+        assert_eq!(fuzzy_score("zzz", "xin wei"), None);
+    }
+
+    #[test]
+    fn test_fuzzy_score_empty_query() {
+        assert_eq!(fuzzy_score("", "anything"), Some(0));
+    }
+
+    #[test]
+    fn test_fuzzy_score_case_insensitive() {
+        assert_eq!(fuzzy_score("XIN", "xin wei"), Some(2));
+    }
+
+    #[test]
+    fn test_top_fuzzy_matches_empty_query() {
+        let chats = vec![make_chat("alice"), make_chat("bob")];
+        assert!(top_fuzzy_matches("", &chats, 5).is_empty());
+    }
+
+    #[test]
+    fn test_top_fuzzy_matches_limit() {
+        let chats = vec![
+            make_chat("alice"),
+            make_chat("alan"),
+            make_chat("alex"),
+            make_chat("albert"),
+            make_chat("alvin"),
+            make_chat("aldous"),
+        ];
+        let results = top_fuzzy_matches("al", &chats, 5);
+        assert_eq!(results.len(), 5);
+    }
+
+    #[test]
+    fn test_top_fuzzy_matches_sorted_by_score() {
+        // "xin" scores 2 on "xin wei", higher span on "xi_n_long"
+        let chats = vec![make_chat("xi_n_long"), make_chat("xin wei")];
+        let results = top_fuzzy_matches("xin", &chats, 5);
+        // "xin wei" (index 1) should rank first (tighter match)
+        assert_eq!(results[0], 1);
+    }
+
+    fn make_chat(name: &str) -> UnifiedChat {
+        UnifiedChat {
+            id: name.to_string(),
+            name: name.to_string(),
+            display_name: None,
+            platform: crate::core::types::Platform::Mock,
+            last_message: None,
+            unread_count: 0,
+            is_group: false,
+            is_pinned: false,
+            is_newsletter: false,
+        }
+    }
+}

--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -7,20 +7,19 @@ pub fn fuzzy_score(query: &str, text: &str) -> Option<usize> {
     if query.is_empty() {
         return Some(0);
     }
-    let query_chars: Vec<char> = query.to_lowercase().chars().collect();
-    let text_chars: Vec<char> = text.to_lowercase().chars().collect();
+    let query_chars: Vec<char> = query.chars().collect();
     let mut qi = 0;
     let mut first_match: Option<usize> = None;
     let mut last_match = 0;
-    for (ti, &tc) in text_chars.iter().enumerate() {
-        if tc == query_chars[qi] {
+    for (ti, tc) in text.chars().enumerate() {
+        if tc.eq_ignore_ascii_case(&query_chars[qi]) {
             if first_match.is_none() {
                 first_match = Some(ti);
             }
             last_match = ti;
             qi += 1;
             if qi == query_chars.len() {
-                return Some(last_match - first_match.unwrap());
+                return Some(last_match - first_match.unwrap() + 1);
             }
         }
     }
@@ -51,13 +50,13 @@ mod tests {
 
     #[test]
     fn test_fuzzy_score_exact() {
-        assert_eq!(fuzzy_score("xin", "xin wei"), Some(2));
+        assert_eq!(fuzzy_score("xin", "xin wei"), Some(3));
     }
 
     #[test]
     fn test_fuzzy_score_scattered() {
-        // 'x' at 0, 'w' at 4 → span 4
-        assert_eq!(fuzzy_score("xw", "xin wei"), Some(4));
+        // 'x' at 0, 'w' at 4 → span = 4 - 0 + 1 = 5
+        assert_eq!(fuzzy_score("xw", "xin wei"), Some(5));
     }
 
     #[test]
@@ -72,7 +71,7 @@ mod tests {
 
     #[test]
     fn test_fuzzy_score_case_insensitive() {
-        assert_eq!(fuzzy_score("XIN", "xin wei"), Some(2));
+        assert_eq!(fuzzy_score("XIN", "xin wei"), Some(3));
     }
 
     #[test]
@@ -93,6 +92,8 @@ mod tests {
         ];
         let results = top_fuzzy_matches("al", &chats, 5);
         assert_eq!(results.len(), 5);
+        assert!(results.iter().all(|&i| i < 6));
+        assert!(!results.contains(&5));
     }
 
     #[test]

--- a/src/tui/widgets/chat_list.rs
+++ b/src/tui/widgets/chat_list.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState},
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 use crate::core::types::UnifiedChat;
-use crate::tui::app_state::ActivePanel;
+use crate::tui::app_state::{ActivePanel, InputMode};
 
 fn make_item(chat: &UnifiedChat, is_selected: bool) -> ListItem<'static> {
     let tag = format!("[{}]", chat.platform);
@@ -41,6 +41,7 @@ pub fn render_chat_list(
     chats: &[UnifiedChat],
     list_state: &mut ListState,
     active_panel: ActivePanel,
+    input_mode: InputMode,
 ) {
     let border_color = if active_panel == ActivePanel::ChatList {
         Color::Cyan
@@ -48,18 +49,30 @@ pub fn render_chat_list(
         Color::DarkGray
     };
 
-    let total_unread: u32 = chats
-        .iter()
-        .filter(|c| !c.is_newsletter)
-        .map(|c| c.unread_count)
-        .sum();
-    let title = if total_unread > 0 {
-        format!(" Chats ({}) ", total_unread)
+    let (title, title_alignment) = if input_mode == InputMode::Editing {
+        let chat_name = list_state
+            .selected()
+            .and_then(|i| chats.get(i))
+            .map(|c| c.display_name.as_deref().unwrap_or(&c.name))
+            .unwrap_or("—");
+        (format!(" ✏  {} ", chat_name), Alignment::Center)
     } else {
-        " Chats ".to_string()
+        let total_unread: u32 = chats
+            .iter()
+            .filter(|c| !c.is_newsletter)
+            .map(|c| c.unread_count)
+            .sum();
+        let t = if total_unread > 0 {
+            format!(" Chats ({}) ", total_unread)
+        } else {
+            " Chats ".to_string()
+        };
+        (t, Alignment::Left)
     };
+
     let block = Block::default()
         .title(title)
+        .title_alignment(title_alignment)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
     let inner = block.inner(area);
@@ -68,7 +81,7 @@ pub fn render_chat_list(
     let selected = list_state.selected().unwrap_or(0);
     let pinned_count = chats.iter().filter(|c| c.is_pinned).count();
 
-    let highlight = Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD);
+    let highlight = Style::default().bg(Color::Blue).fg(Color::White).add_modifier(Modifier::BOLD);
 
     if pinned_count == 0 {
         // No pinned chats — plain scrollable list

--- a/src/tui/widgets/chat_list.rs
+++ b/src/tui/widgets/chat_list.rs
@@ -20,14 +20,19 @@ fn make_item(chat: &UnifiedChat, is_selected: bool) -> ListItem<'static> {
     // Embed selector so column layout is always consistent regardless of which list is active
     let selector = if is_selected { "▶ " } else { "  " };
     let pin_tag = if chat.is_pinned { "* " } else { "  " };
-    ListItem::new(Line::from(vec![
+    let mut spans = vec![
         Span::raw(selector),
         Span::styled(pin_tag.to_string(), Style::default().fg(Color::Yellow)),
-        Span::styled(tag, Style::default().fg(Color::DarkGray)),
-        Span::raw(" "),
-        Span::styled(name, Style::default().fg(Color::White)),
-        Span::styled(unread, Style::default().fg(Color::Yellow)),
-    ]))
+    ];
+    if chat.is_newsletter {
+        spans.push(Span::styled("[NL]", Style::default().fg(Color::Cyan)));
+    } else {
+        spans.push(Span::styled(tag, Style::default().fg(Color::DarkGray)));
+    }
+    spans.push(Span::raw(" "));
+    spans.push(Span::styled(name, Style::default().fg(Color::White)));
+    spans.push(Span::styled(unread, Style::default().fg(Color::Yellow)));
+    ListItem::new(Line::from(spans))
 }
 
 pub fn render_chat_list(
@@ -43,8 +48,18 @@ pub fn render_chat_list(
         Color::DarkGray
     };
 
+    let total_unread: u32 = chats
+        .iter()
+        .filter(|c| !c.is_newsletter)
+        .map(|c| c.unread_count)
+        .sum();
+    let title = if total_unread > 0 {
+        format!(" Chats ({}) ", total_unread)
+    } else {
+        " Chats ".to_string()
+    };
     let block = Block::default()
-        .title(" Chats ")
+        .title(title)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
     let inner = block.inner(area);

--- a/src/tui/widgets/input_bar.rs
+++ b/src/tui/widgets/input_bar.rs
@@ -20,6 +20,7 @@ pub fn render_input_bar(
         InputMode::Settings => ("SETTINGS", Color::Cyan),
         InputMode::Renaming => ("RENAME", Color::Magenta),
         InputMode::ChatMenu => ("MENU", Color::Yellow),
+        InputMode::Searching => ("SEARCH", Color::Blue),
     };
 
     let block = Block::default()

--- a/src/tui/widgets/input_bar.rs
+++ b/src/tui/widgets/input_bar.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    layout::Rect,
+    layout::{Alignment, Rect},
     style::{Color, Style},
     widgets::{Block, Borders, Paragraph},
     Frame,
@@ -14,17 +14,18 @@ pub fn render_input_bar(
     textarea: &TextArea<'static>,
     mode: InputMode,
 ) {
-    let (mode_tag, border_color) = match mode {
-        InputMode::Normal => ("NORMAL", Color::DarkGray),
-        InputMode::Editing => ("INSERT", Color::Yellow),
-        InputMode::Settings => ("SETTINGS", Color::Cyan),
-        InputMode::Renaming => ("RENAME", Color::Magenta),
-        InputMode::ChatMenu => ("MENU", Color::Yellow),
-        InputMode::Searching => ("SEARCH", Color::Blue),
+    let (mode_tag, border_color, title_align) = match mode {
+        InputMode::Normal   => ("NORMAL",   Color::DarkGray, Alignment::Left),
+        InputMode::Editing  => ("✏  INSERT", Color::Yellow,   Alignment::Center),
+        InputMode::Settings => ("SETTINGS", Color::Cyan,     Alignment::Left),
+        InputMode::Renaming => ("RENAME",   Color::Magenta,  Alignment::Left),
+        InputMode::ChatMenu => ("MENU",     Color::Yellow,   Alignment::Left),
+        InputMode::Searching => ("SEARCH",  Color::Cyan,     Alignment::Left),
     };
 
     let block = Block::default()
-        .title(format!(" [{}] ", mode_tag))
+        .title(format!(" {} ", mode_tag))
+        .title_alignment(title_align)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
 

--- a/src/tui/widgets/message_view.rs
+++ b/src/tui/widgets/message_view.rs
@@ -59,6 +59,7 @@ pub fn render_message_view(
     chat_name: &str,
     scroll_offset: u16,
     active_panel: ActivePanel,
+    new_message_count: usize,
 ) {
     let border_color = if active_panel == ActivePanel::MessageView {
         Color::Cyan
@@ -78,13 +79,46 @@ pub fn render_message_view(
         return;
     }
 
+    // Find the index of the first "new" message by counting backwards
+    // through incoming messages until we reach new_message_count.
+    let new_start_idx = if new_message_count > 0 {
+        let mut counted = 0;
+        let mut idx = None;
+        for (i, msg) in messages.iter().enumerate().rev() {
+            if !msg.is_outgoing {
+                counted += 1;
+                if counted == new_message_count {
+                    idx = Some(i);
+                    break;
+                }
+            }
+        }
+        idx
+    } else {
+        None
+    };
+
     let mut lines: Vec<Line> = Vec::new();
 
-    for msg in messages {
+    for (i, msg) in messages.iter().enumerate() {
+        // Insert a full-width "─── N new ───" separator before the first new message
+        if Some(i) == new_start_idx {
+            let content_width = area.width.saturating_sub(2) as usize;
+            let label = format!(" {} new ", new_message_count);
+            let dashes = content_width.saturating_sub(label.len());
+            let left = dashes / 2;
+            let right = dashes - left;
+            let separator = format!("{}{}{}", "─".repeat(left), label, "─".repeat(right));
+            lines.push(Line::styled(separator, Style::default().fg(Color::Yellow)));
+        }
+
         let time = msg.timestamp.with_timezone(&Local).format("%H:%M").to_string();
+        let is_new = new_start_idx.map(|s| i >= s).unwrap_or(false) && !msg.is_outgoing;
 
         let (sender_color, msg_color) = if msg.is_outgoing {
             (Color::Green, Color::White)
+        } else if is_new {
+            (Color::Yellow, Color::White)
         } else {
             (Color::Cyan, Color::Gray)
         };

--- a/src/tui/widgets/mod.rs
+++ b/src/tui/widgets/mod.rs
@@ -5,3 +5,4 @@ pub mod message_view;
 pub mod qr_overlay;
 pub mod settings_overlay;
 pub mod status_bar;
+pub mod search_overlay;

--- a/src/tui/widgets/mod.rs
+++ b/src/tui/widgets/mod.rs
@@ -3,6 +3,6 @@ pub mod chat_menu;
 pub mod input_bar;
 pub mod message_view;
 pub mod qr_overlay;
-pub mod settings_overlay;
 pub mod search_overlay;
+pub mod settings_overlay;
 pub mod status_bar;

--- a/src/tui/widgets/mod.rs
+++ b/src/tui/widgets/mod.rs
@@ -4,5 +4,5 @@ pub mod input_bar;
 pub mod message_view;
 pub mod qr_overlay;
 pub mod settings_overlay;
-pub mod status_bar;
 pub mod search_overlay;
+pub mod status_bar;

--- a/src/tui/widgets/search_overlay.rs
+++ b/src/tui/widgets/search_overlay.rs
@@ -2,7 +2,7 @@ use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, block::Title},
     Frame,
 };
 
@@ -29,20 +29,24 @@ pub fn render_search_overlay(
 
     f.render_widget(Clear, popup_area);
 
+    let title = Title::from(Line::from(vec![
+        Span::styled(" / ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        Span::styled("Find Chat ", Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ]));
     let block = Block::default()
-        .title(" Find Chat ")
+        .title(title)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Blue));
+        .border_style(Style::default().fg(Color::Cyan));
     let inner = block.inner(popup_area);
     f.render_widget(block, popup_area);
 
     // Query line
     let query_area = Rect { x: inner.x, y: inner.y, width: inner.width, height: 1 };
-    f.render_widget(
-        Paragraph::new(format!("/ {}▌", state.query))
-            .style(Style::default().fg(Color::White)),
-        query_area,
-    );
+    let query_line = Line::from(vec![
+        Span::styled("/ ", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+        Span::styled(format!("{}▌", state.query), Style::default().fg(Color::White)),
+    ]);
+    f.render_widget(Paragraph::new(query_line), query_area);
 
     if result_count == 0 {
         return;
@@ -65,8 +69,8 @@ pub fn render_search_overlay(
     };
 
     let highlight = Style::default()
-        .bg(Color::Blue)
-        .fg(Color::White)
+        .bg(Color::Cyan)
+        .fg(Color::Black)
         .add_modifier(Modifier::BOLD);
 
     let items: Vec<ListItem> = state

--- a/src/tui/widgets/search_overlay.rs
+++ b/src/tui/widgets/search_overlay.rs
@@ -73,21 +73,23 @@ pub fn render_search_overlay(
         .results
         .iter()
         .enumerate()
-        .map(|(pos, &idx)| {
-            let chat = &chats[idx];
+        .take(result_count)
+        .filter_map(|(pos, &idx)| {
+            let chat = chats.get(idx)?;
             let name = chat.display_name.as_deref().unwrap_or(&chat.name);
             let selector = if pos == state.selected { "▶ " } else { "  " };
             let tag = format!("[{}] ", chat.platform);
-            ListItem::new(Line::from(vec![
+            Some(ListItem::new(Line::from(vec![
                 Span::raw(selector),
                 Span::styled(tag, Style::default().fg(Color::DarkGray)),
                 Span::styled(name.to_string(), Style::default().fg(Color::White)),
-            ]))
+            ])))
         })
         .collect();
 
     let mut list_state = ListState::default();
-    list_state.select(Some(state.selected));
+    let clamped_selected = state.selected.min(items.len().saturating_sub(1));
+    list_state.select(Some(clamped_selected));
     f.render_stateful_widget(
         List::new(items).highlight_style(highlight),
         results_area,

--- a/src/tui/widgets/search_overlay.rs
+++ b/src/tui/widgets/search_overlay.rs
@@ -1,0 +1,96 @@
+use ratatui::{
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
+    Frame,
+};
+
+use crate::core::types::UnifiedChat;
+use crate::tui::app_state::SearchState;
+
+pub fn render_search_overlay(
+    f: &mut Frame,
+    chat_list_area: Rect,
+    state: &SearchState,
+    chats: &[UnifiedChat],
+) {
+    let result_count = state.results.len().min(5);
+    // 2 borders + 1 query line + (1 divider + N results) if any results
+    let inner_height = 1 + if result_count > 0 { 1 + result_count } else { 0 };
+    let height = (2 + inner_height as u16).min(chat_list_area.height);
+
+    let popup_area = Rect {
+        x: chat_list_area.x,
+        y: chat_list_area.y,
+        width: chat_list_area.width,
+        height,
+    };
+
+    f.render_widget(Clear, popup_area);
+
+    let block = Block::default()
+        .title(" Find Chat ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Blue));
+    let inner = block.inner(popup_area);
+    f.render_widget(block, popup_area);
+
+    // Query line
+    let query_area = Rect { x: inner.x, y: inner.y, width: inner.width, height: 1 };
+    f.render_widget(
+        Paragraph::new(format!("/ {}▌", state.query))
+            .style(Style::default().fg(Color::White)),
+        query_area,
+    );
+
+    if result_count == 0 {
+        return;
+    }
+
+    // Divider
+    let sep_area = Rect { x: inner.x, y: inner.y + 1, width: inner.width, height: 1 };
+    f.render_widget(
+        Paragraph::new("─".repeat(inner.width as usize))
+            .style(Style::default().fg(Color::DarkGray)),
+        sep_area,
+    );
+
+    // Results list
+    let results_area = Rect {
+        x: inner.x,
+        y: inner.y + 2,
+        width: inner.width,
+        height: result_count as u16,
+    };
+
+    let highlight = Style::default()
+        .bg(Color::Blue)
+        .fg(Color::White)
+        .add_modifier(Modifier::BOLD);
+
+    let items: Vec<ListItem> = state
+        .results
+        .iter()
+        .enumerate()
+        .map(|(pos, &idx)| {
+            let chat = &chats[idx];
+            let name = chat.display_name.as_deref().unwrap_or(&chat.name);
+            let selector = if pos == state.selected { "▶ " } else { "  " };
+            let tag = format!("[{}] ", chat.platform);
+            ListItem::new(Line::from(vec![
+                Span::raw(selector),
+                Span::styled(tag, Style::default().fg(Color::DarkGray)),
+                Span::styled(name.to_string(), Style::default().fg(Color::White)),
+            ]))
+        })
+        .collect();
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(state.selected));
+    f.render_stateful_widget(
+        List::new(items).highlight_style(highlight),
+        results_area,
+        &mut list_state,
+    );
+}

--- a/src/tui/widgets/status_bar.rs
+++ b/src/tui/widgets/status_bar.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     layout::Rect,
-    style::{Color, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::Paragraph,
     Frame,
@@ -31,34 +31,37 @@ pub fn render_status_bar(
         InputMode::Searching => "Type to filter | j/k:Navigate | Enter:Open+Insert | Esc:Cancel",
     };
 
-    let mut spans = Vec::new();
+    // Mode pill: colored badge on the left, rest of bar stays on black
+    let (pill_label, pill_bg, pill_fg) = match mode {
+        InputMode::Normal   => (" NORMAL ",  Color::DarkGray, Color::Black),
+        InputMode::Editing  => (" ✏ INSERT ", Color::Yellow,   Color::Black),
+        InputMode::Settings => (" SETTINGS ", Color::Cyan,    Color::Black),
+        InputMode::Renaming => (" RENAME ",  Color::Magenta,  Color::Black),
+        InputMode::ChatMenu => (" MENU ",    Color::Yellow,   Color::Black),
+        InputMode::Searching => (" SEARCH ", Color::Cyan,     Color::Black),
+    };
 
-    // Version
-    spans.push(Span::styled(
-        format!(" v{} ", env!("CARGO_PKG_VERSION")),
-        Style::default().fg(Color::DarkGray),
-    ));
-    spans.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
+    let sep = Style::default().fg(Color::DarkGray);
+
+    let mut spans = vec![
+        Span::styled(pill_label, Style::default().bg(pill_bg).fg(pill_fg).add_modifier(Modifier::BOLD)),
+        Span::styled(" │ ", sep),
+        Span::styled(format!("v{} ", env!("CARGO_PKG_VERSION")), Style::default().fg(Color::DarkGray)),
+        Span::styled(" │ ", sep),
+    ];
 
     if mock_enabled {
         spans.push(Span::styled(" ● ", Style::default().fg(Color::Green)));
         spans.push(Span::styled("Mock", Style::default().fg(Color::DarkGray)));
-        spans.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
+        spans.push(Span::styled(" │ ", sep));
     }
 
-    // WhatsApp status indicator
-    let wa_color = if whatsapp_connected {
-        Color::Green
-    } else {
-        Color::Red
-    };
+    let wa_color = if whatsapp_connected { Color::Green } else { Color::Red };
     spans.push(Span::styled(" ● ", Style::default().fg(wa_color)));
     spans.push(Span::styled("WA", Style::default().fg(Color::DarkGray)));
-
-    spans.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
+    spans.push(Span::styled(" │ ", sep));
     spans.push(Span::styled(hints, Style::default().fg(Color::DarkGray)));
 
-    let line = Line::from(spans);
-    let paragraph = Paragraph::new(line).style(Style::default().bg(Color::Black));
+    let paragraph = Paragraph::new(Line::from(spans)).style(Style::default().bg(Color::Black));
     f.render_widget(paragraph, area);
 }

--- a/src/tui/widgets/status_bar.rs
+++ b/src/tui/widgets/status_bar.rs
@@ -28,6 +28,7 @@ pub fn render_status_bar(
         InputMode::Settings => "j/k:Navigate | Enter/Space:Toggle | Ctrl+s:Save | Esc:Cancel",
         InputMode::Renaming => "Enter:Confirm | Esc:Cancel | Type new name",
         InputMode::ChatMenu => "j/k:Navigate | p/Enter:Confirm | Esc:Close",
+        InputMode::Searching => "Type to filter | j/k:Navigate | Enter:Open+Insert | Esc:Cancel",
     };
 
     let mut spans = Vec::new();


### PR DESCRIPTION
## Summary

### 🔍 `/` Fuzzy Chat Search
Press `/` to open a search popup over the chat list. Type to fuzzy-filter chat names (display names / renamed tags), top 5 results shown ranked by match tightness. Navigate with `j`/`k`, press `Enter` to jump to the chat and enter insert mode instantly, `Esc` to cancel.

- Cyan-bordered popup with styled `/ Find Chat` title
- Cyan `/` prefix on the query line, cyan highlight on selected result
- Fuzzy scoring by match span — tighter matches rank higher

### 📬 Auto-clear Unread When Read on Another Device
When you read a chat on your iPhone or WhatsApp Web, a `ReadSelf` receipt arrives and now automatically clears the unread count and `─── N new ───` separator in the TUI — no need to navigate to the chat manually.

### 🎨 Chat Selection Highlight
Selected chat row now uses **blue background + white text** for clear focus indication (was DarkGray).

### ✏ INSERT Mode Indicators
Three simultaneous signals when composing a message:
- **Chat list header** → changes from `Chats` to `✏ {chat name}` (centered) so you always see which chat you're writing to
- **Input box border** → `✏  INSERT` centered on the yellow border instead of a small corner tag
- **Status bar** → mode pill badge (`✏ INSERT` in yellow) at the far left — consistent with vim-airline style, no color conflicts with WA/Mock indicators

## Test Plan
- [ ] Press `/` → search popup appears with cyan border and `/ Find Chat` title
- [ ] Type partial name → fuzzy results appear, ranked by match tightness
- [ ] `j`/`k` navigates results, `Enter` jumps to chat + enters INSERT mode
- [ ] `Esc` closes search without navigating
- [ ] Read a chat on iPhone → unread count clears in TUI automatically
- [ ] Selected chat shows blue bg / white fg highlight
- [ ] Pressing `i` or `Enter` on a chat → chat list header shows `✏ {name}`, input border shows `✏  INSERT` centered, status bar pill turns yellow

🤖 Generated with [Claude Code](https://claude.com/claude-code)