### PR TITLE
feat: AI autocomplete, mute chat, contact sync, UX fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +412,26 @@ dependencies = [
  "serde_json",
  "time",
  "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -758,6 +784,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_filter"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +911,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1031,6 +1081,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,10 +1175,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1306,6 +1477,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,6 +1726,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1783,50 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -1685,6 +1939,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -2002,6 +2262,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2122,6 +2422,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scheduled-thread-pool"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2135,6 +2444,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2210,6 +2542,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2390,6 +2734,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,6 +2751,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2538,6 +2912,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2556,6 +2940,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -2654,6 +3039,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2725,6 +3155,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tui-textarea"
@@ -3059,6 +3495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "waproto"
 version = "0.2.0"
 source = "git+https://github.com/jlucaso1/whatsapp-rust#181d527196bdf8de6d2529b16b489293a48c4b41"
@@ -3103,6 +3548,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee85afca410ac4abba5b584b12e77ea225db6ee5471d0aebaae0861166f9378a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3169,6 +3628,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10053fbf9a374174094915bbce141e87a6bf32ecd9a002980db4b638405e8962"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3324,6 +3793,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -3726,10 +4206,12 @@ dependencies = [
  "qrcode",
  "rand 0.8.5",
  "ratatui",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
  "toml 0.8.23",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,5 @@ dirs = "5"
 whatsapp-rust = { git = "https://github.com/jlucaso1/whatsapp-rust", default-features = true }
 qrcode = "0.14"
 tui-textarea = { version = "0.7", features = ["crossterm"] }
+reqwest = { version = "0.12", features = ["json"] }
+tokio-util = { version = "0.7", features = ["rt"] }

--- a/configs/default.toml
+++ b/configs/default.toml
@@ -17,11 +17,11 @@ enabled = true
 # phone_number = "+1234567890"
 
 [ai]
-enabled = false
-# provider = "ollama"          # ollama | openai | anthropic | gemini
-# base_url = "http://localhost:11434"
-# api_key = ""
-# model = "qwen2.5:1.5b-instruct"
-# context_messages = 10
-# summary_threshold = 50
-# debounce_ms = 500
+enabled = true
+provider = "ollama"
+base_url = "http://localhost:8080"
+model = "qwen2.5-1.5b-instruct-q4_k_m"
+context_messages = 10
+summary_threshold = 50
+debounce_ms = 500
+debug = true

--- a/configs/default.toml
+++ b/configs/default.toml
@@ -15,3 +15,13 @@ message_interval_secs = 3
 [whatsapp]
 enabled = true
 # phone_number = "+1234567890"
+
+[ai]
+# enabled = false
+# provider = "ollama"          # ollama | openai | anthropic | gemini
+# base_url = "http://localhost:11434"
+# api_key = ""
+# model = "qwen2.5:1.5b-instruct"
+# context_messages = 10
+# summary_threshold = 50
+# debounce_ms = 500

--- a/configs/default.toml
+++ b/configs/default.toml
@@ -17,7 +17,7 @@ enabled = true
 # phone_number = "+1234567890"
 
 [ai]
-# enabled = false
+enabled = false
 # provider = "ollama"          # ollama | openai | anthropic | gemini
 # base_url = "http://localhost:11434"
 # api_key = ""

--- a/docs/plans/2026-03-06-ai-autocomplete-design.md
+++ b/docs/plans/2026-03-06-ai-autocomplete-design.md
@@ -1,0 +1,175 @@
+# AI Autocomplete Design
+
+Date: 2026-03-06
+
+## Overview
+
+Add context-aware ghost-text autocomplete to the chat input bar. When typing, the AI suggests a completion inline (greyed out after the cursor). Accepted with `Tab` or `→`, dismissed with `Esc` or any other key.
+
+Supports local models (Ollama, llama.cpp) and cloud providers (OpenAI-compatible, Anthropic, Gemini). Optimised for Qwen2.5-1.5B-Instruct running locally — zero cost, low latency.
+
+## Architecture
+
+```
+App (event loop)
+├── AiWorker (tokio task)
+│   ├── debounce timer (500ms, resets on keystroke)
+│   ├── CancellationToken (cancels inflight request on new trigger)
+│   └── Box<dyn AiProvider>
+│       ├── OpenAiClient   (covers Ollama, llama.cpp, OpenAI, Groq, Mistral)
+│       ├── AnthropicClient
+│       └── GeminiClient
+└── ContextBuilder
+    ├── Conversation summary (stored in SQLite per chat_id)
+    └── Last N raw messages verbatim
+```
+
+### New modules
+
+- `src/ai/mod.rs` — AiWorker, request/response types, cancellation
+- `src/ai/context.rs` — hybrid context builder
+- `src/ai/providers/mod.rs` — AiProvider trait
+- `src/ai/providers/openai.rs` — OpenAI-compatible client
+- `src/ai/providers/anthropic.rs` — Anthropic Messages API client
+- `src/ai/providers/gemini.rs` — Gemini generateContent API client
+
+## Trigger Behaviour
+
+- **Debounced:** fires 500ms after the user stops typing in INSERT mode
+- **On-demand:** `Ctrl+Space` fires immediately, bypassing the debounce
+- Only triggers when there is partial text in the input bar
+- Previous inflight request is cancelled when a new one fires
+
+## Context Builder
+
+### Prompt structure
+
+```
+[system]
+You are a chat autocomplete assistant. Complete the user's message naturally
+based on conversation context. Reply with ONLY the completion text, no explanation.
+
+[conversation summary — optional, ~150 tokens]
+Stored per chat_id in SQLite. Regenerated every 50 messages (configurable).
+
+[last N messages — default 10]
+[You]: ...
+[Them]: ...
+
+[user]
+Complete this: <partial input>
+```
+
+### Summary lifecycle
+
+- After every `summary_threshold` new messages, a background task summarises
+  older messages and stores the result in the `preferences` table (key: `ai_summary:<chat_id>`)
+- Summary generation never blocks autocomplete — it runs async in the background
+
+### Token budget (Qwen2.5-1.5B-Instruct)
+
+| Part             | Approx tokens |
+|------------------|--------------|
+| System prompt    | ~50          |
+| Summary          | ~150         |
+| Last 10 messages | ~300–500     |
+| Partial input    | ~20          |
+| **Total**        | **~520–720** |
+
+## AI Worker
+
+```rust
+struct AiWorker {
+    provider: Box<dyn AiProvider>,
+    debounce: Duration,          // default 500ms
+    cancel_token: Option<CancellationToken>,
+}
+```
+
+### New AppEvent variants
+
+```rust
+AiRequest { chat_id: String, partial_input: String }
+AiSuggestion(String)
+AiError(String)   // shown briefly in status bar, non-fatal
+```
+
+### Ghost text rendering
+
+- `app_state.ai_suggestion: Option<String>` holds the current suggestion
+- `render_input_bar` renders the suggestion text in `DarkGray` after the cursor when in INSERT mode
+- `Tab` or `→` at end-of-input: appends suggestion to textarea, clears `ai_suggestion`
+- Any other key: clears `ai_suggestion`
+
+## Provider Trait
+
+```rust
+#[async_trait]
+pub trait AiProvider: Send + Sync {
+    async fn complete(
+        &self,
+        req: CompletionRequest,
+        cancel: CancellationToken,
+    ) -> Result<String>;
+}
+
+pub struct CompletionRequest {
+    pub system: String,
+    pub context: Vec<ContextMessage>,
+    pub partial_input: String,
+}
+```
+
+### Provider coverage
+
+| Config value | Implementation | Covers |
+|-------------|---------------|--------|
+| `ollama`    | openai.rs     | Ollama, llama.cpp server |
+| `openai`    | openai.rs     | OpenAI, Groq, Together, Mistral |
+| `anthropic` | anthropic.rs  | Claude models |
+| `gemini`    | gemini.rs     | Gemini models |
+
+## Configuration
+
+New `[ai]` section in `configs/default.toml`:
+
+```toml
+[ai]
+enabled = false                          # opt-in, off by default
+provider = "ollama"                      # ollama | openai | anthropic | gemini
+base_url = "http://localhost:11434"      # for ollama/llama.cpp/openai-compat
+api_key = ""                             # leave empty for local models
+model = "qwen2.5:1.5b-instruct"
+
+context_messages = 10                    # last N messages to include verbatim
+summary_threshold = 50                   # regenerate summary every N messages
+debounce_ms = 500                        # ms to wait after last keystroke
+```
+
+## Cost Estimate
+
+| Mode                        | Cost per suggestion |
+|-----------------------------|-------------------|
+| Ollama / llama.cpp (local)  | $0                |
+| OpenAI gpt-4o-mini          | ~$0.0001          |
+| Anthropic claude-haiku-4-5  | ~$0.0001          |
+| Gemini flash                | ~$0.00005         |
+
+## Files to Create / Modify
+
+| File | Change |
+|------|--------|
+| `src/ai/mod.rs` | New — AiWorker, request/event types |
+| `src/ai/context.rs` | New — context builder, summary logic |
+| `src/ai/providers/mod.rs` | New — AiProvider trait |
+| `src/ai/providers/openai.rs` | New — OpenAI-compat client |
+| `src/ai/providers/anthropic.rs` | New — Anthropic client |
+| `src/ai/providers/gemini.rs` | New — Gemini client |
+| `src/config/settings.rs` | Add `AiConfig` struct |
+| `src/tui/app_state.rs` | Add `ai_suggestion: Option<String>` |
+| `src/tui/event.rs` | Add `AiRequest`, `AiSuggestion`, `AiError` variants |
+| `src/tui/widgets/input_bar.rs` | Render ghost text in DarkGray |
+| `src/tui/keybindings.rs` | Add `Tab`/`Ctrl+Space` actions |
+| `src/app.rs` | Spawn AiWorker, handle new events |
+| `src/storage/preferences.rs` | Store/retrieve AI summary per chat |
+| `Cargo.toml` | Add `reqwest`, `async-trait`, `tokio-util` deps |

--- a/docs/plans/2026-03-06-ai-autocomplete.md
+++ b/docs/plans/2026-03-06-ai-autocomplete.md
@@ -1,0 +1,1401 @@
+# AI Autocomplete Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add ghost-text autocomplete to the chat input bar, powered by a configurable AI backend (local Ollama/llama.cpp or cloud OpenAI/Anthropic/Gemini).
+
+**Architecture:** An `AiWorker` tokio task holds a `CancellationToken` and a `Box<dyn AiProvider>`. It receives `AiRequest` events, cancels any inflight request, and spawns a new suggestion task that sends `AppEvent::AiSuggestion` back into the main event loop. Context is assembled from a stored per-chat summary plus the last N raw messages.
+
+**Tech Stack:** Rust async/await, tokio, tokio-util (CancellationToken), reqwest (HTTP), ratatui, existing rusqlite preferences table.
+
+---
+
+### Task 1: Add dependencies and `[ai]` config section
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `src/config/settings.rs`
+- Modify: `configs/default.toml`
+
+**Step 1: Add crate dependencies**
+
+In `Cargo.toml`, add after the existing deps:
+
+```toml
+reqwest = { version = "0.12", features = ["json"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+```
+
+(`async-trait` is already present.)
+
+**Step 2: Add `AiConfig` struct to `src/config/settings.rs`**
+
+Add the struct and defaults:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_ai_provider")]
+    pub provider: String,
+    #[serde(default = "default_ai_base_url")]
+    pub base_url: String,
+    #[serde(default)]
+    pub api_key: String,
+    #[serde(default = "default_ai_model")]
+    pub model: String,
+    #[serde(default = "default_context_messages")]
+    pub context_messages: usize,
+    #[serde(default = "default_summary_threshold")]
+    pub summary_threshold: usize,
+    #[serde(default = "default_debounce_ms")]
+    pub debounce_ms: u64,
+}
+
+fn default_ai_provider() -> String { "ollama".to_string() }
+fn default_ai_base_url() -> String { "http://localhost:11434".to_string() }
+fn default_ai_model() -> String { "qwen2.5:1.5b-instruct".to_string() }
+fn default_context_messages() -> usize { 10 }
+fn default_summary_threshold() -> usize { 50 }
+fn default_debounce_ms() -> u64 { 500 }
+
+impl Default for AiConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            provider: default_ai_provider(),
+            base_url: default_ai_base_url(),
+            api_key: String::new(),
+            model: default_ai_model(),
+            context_messages: default_context_messages(),
+            summary_threshold: default_summary_threshold(),
+            debounce_ms: default_debounce_ms(),
+        }
+    }
+}
+```
+
+Add `pub ai: AiConfig` field to `AppConfig` with `#[serde(default)]`. Add it to both `AppConfig::default()` and the struct definition.
+
+**Step 3: Update `configs/default.toml` with commented AI section**
+
+```toml
+[ai]
+# enabled = false
+# provider = "ollama"          # ollama | openai | anthropic | gemini
+# base_url = "http://localhost:11434"
+# api_key = ""
+# model = "qwen2.5:1.5b-instruct"
+# context_messages = 10
+# summary_threshold = 50
+# debounce_ms = 500
+```
+
+**Step 4: Verify it compiles**
+
+```bash
+cargo check
+```
+Expected: no errors.
+
+**Step 5: Commit**
+
+```bash
+git add Cargo.toml src/config/settings.rs configs/default.toml
+git commit -m "feat: add AiConfig and reqwest/tokio-util dependencies"
+```
+
+---
+
+### Task 2: Provider trait and OpenAI-compatible client
+
+**Files:**
+- Create: `src/ai/mod.rs`
+- Create: `src/ai/providers/mod.rs`
+- Create: `src/ai/providers/openai.rs`
+
+**Step 1: Write unit test for context message formatting**
+
+In `src/ai/providers/mod.rs`, add a test at the bottom:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_message_display_outgoing() {
+        let msg = ContextMessage { role: MessageRole::User, content: "hello".to_string() };
+        assert_eq!(msg.to_chat_line(), "[You]: hello");
+    }
+
+    #[test]
+    fn context_message_display_incoming() {
+        let msg = ContextMessage { role: MessageRole::Assistant, content: "hi".to_string() };
+        assert_eq!(msg.to_chat_line(), "[Them]: hi");
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cargo test ai::providers
+```
+Expected: compile error — module doesn't exist yet.
+
+**Step 3: Create `src/ai/providers/mod.rs`**
+
+```rust
+use async_trait::async_trait;
+use anyhow::Result;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone)]
+pub enum MessageRole {
+    User,
+    Assistant,
+}
+
+#[derive(Debug, Clone)]
+pub struct ContextMessage {
+    pub role: MessageRole,
+    pub content: String,
+}
+
+impl ContextMessage {
+    pub fn to_chat_line(&self) -> String {
+        match self.role {
+            MessageRole::User => format!("[You]: {}", self.content),
+            MessageRole::Assistant => format!("[Them]: {}", self.content),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CompletionRequest {
+    pub model: String,
+    pub system: String,
+    pub context: Vec<ContextMessage>,
+    pub partial_input: String,
+}
+
+#[async_trait]
+pub trait AiProvider: Send + Sync {
+    async fn complete(&self, req: CompletionRequest, cancel: CancellationToken) -> Result<String>;
+}
+
+pub mod openai;
+pub mod anthropic;
+pub mod gemini;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_message_display_outgoing() {
+        let msg = ContextMessage { role: MessageRole::User, content: "hello".to_string() };
+        assert_eq!(msg.to_chat_line(), "[You]: hello");
+    }
+
+    #[test]
+    fn context_message_display_incoming() {
+        let msg = ContextMessage { role: MessageRole::Assistant, content: "hi".to_string() };
+        assert_eq!(msg.to_chat_line(), "[Them]: hi");
+    }
+}
+```
+
+**Step 4: Create `src/ai/providers/openai.rs`**
+
+```rust
+use async_trait::async_trait;
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+
+use super::{AiProvider, CompletionRequest};
+
+pub struct OpenAiClient {
+    pub base_url: String,
+    pub api_key: String,
+    client: reqwest::Client,
+}
+
+impl OpenAiClient {
+    pub fn new(base_url: String, api_key: String) -> Self {
+        Self {
+            base_url,
+            api_key,
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ChatMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Serialize)]
+struct ChatRequest {
+    model: String,
+    messages: Vec<ChatMessage>,
+    max_tokens: u32,
+    stream: bool,
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<Choice>,
+}
+
+#[derive(Deserialize)]
+struct Choice {
+    message: ChoiceMessage,
+}
+
+#[derive(Deserialize)]
+struct ChoiceMessage {
+    content: String,
+}
+
+#[async_trait]
+impl AiProvider for OpenAiClient {
+    async fn complete(&self, req: CompletionRequest, cancel: CancellationToken) -> Result<String> {
+        let mut messages = vec![
+            ChatMessage { role: "system".to_string(), content: req.system.clone() },
+        ];
+
+        for ctx_msg in &req.context {
+            messages.push(ChatMessage {
+                role: "user".to_string(),
+                content: ctx_msg.to_chat_line(),
+            });
+        }
+
+        messages.push(ChatMessage {
+            role: "user".to_string(),
+            content: format!("Complete this message (reply with ONLY the completion, nothing else): {}", req.partial_input),
+        });
+
+        let body = ChatRequest {
+            model: req.model.clone(),
+            messages,
+            max_tokens: 80,
+            stream: false,
+        };
+
+        let mut request = self.client
+            .post(format!("{}/v1/chat/completions", self.base_url))
+            .json(&body);
+
+        if !self.api_key.is_empty() {
+            request = request.bearer_auth(&self.api_key);
+        }
+
+        tokio::select! {
+            _ = cancel.cancelled() => Err(anyhow!("cancelled")),
+            res = request.send() => {
+                let resp: ChatResponse = res?.json().await?;
+                Ok(resp.choices.into_iter().next()
+                    .map(|c| c.message.content.trim().to_string())
+                    .unwrap_or_default())
+            }
+        }
+    }
+}
+```
+
+**Step 5: Create stub files for anthropic and gemini (implement in Task 3)**
+
+`src/ai/providers/anthropic.rs`:
+```rust
+// Stub — implemented in Task 3
+use async_trait::async_trait;
+use anyhow::Result;
+use tokio_util::sync::CancellationToken;
+use super::{AiProvider, CompletionRequest};
+
+pub struct AnthropicClient {
+    pub api_key: String,
+    client: reqwest::Client,
+}
+
+impl AnthropicClient {
+    pub fn new(api_key: String) -> Self {
+        Self { api_key, client: reqwest::Client::new() }
+    }
+}
+
+#[async_trait]
+impl AiProvider for AnthropicClient {
+    async fn complete(&self, _req: CompletionRequest, _cancel: CancellationToken) -> Result<String> {
+        anyhow::bail!("Anthropic provider not yet implemented")
+    }
+}
+```
+
+`src/ai/providers/gemini.rs`:
+```rust
+// Stub — implemented in Task 3
+use async_trait::async_trait;
+use anyhow::Result;
+use tokio_util::sync::CancellationToken;
+use super::{AiProvider, CompletionRequest};
+
+pub struct GeminiClient {
+    pub api_key: String,
+    client: reqwest::Client,
+}
+
+impl GeminiClient {
+    pub fn new(api_key: String) -> Self {
+        Self { api_key, client: reqwest::Client::new() }
+    }
+}
+
+#[async_trait]
+impl AiProvider for GeminiClient {
+    async fn complete(&self, _req: CompletionRequest, _cancel: CancellationToken) -> Result<String> {
+        anyhow::bail!("Gemini provider not yet implemented")
+    }
+}
+```
+
+**Step 6: Create `src/ai/mod.rs`** (minimal, worker added in Task 5)
+
+```rust
+pub mod providers;
+pub mod context;
+pub mod worker;
+```
+
+**Step 7: Create stub `src/ai/context.rs`** (implemented in Task 4)
+
+```rust
+// Stub — implemented in Task 4
+```
+
+**Step 8: Create stub `src/ai/worker.rs`** (implemented in Task 5)
+
+```rust
+// Stub — implemented in Task 5
+```
+
+**Step 9: Register module in `src/main.rs`**
+
+Add `mod ai;` after the existing `mod` declarations in `src/main.rs`.
+
+**Step 10: Run tests**
+
+```bash
+cargo test ai::providers::tests
+```
+Expected: 2 tests pass.
+
+**Step 11: Commit**
+
+```bash
+git add src/ai/ src/main.rs
+git commit -m "feat: add AI provider trait and OpenAI-compatible client"
+```
+
+---
+
+### Task 3: Anthropic and Gemini provider implementations
+
+**Files:**
+- Modify: `src/ai/providers/anthropic.rs`
+- Modify: `src/ai/providers/gemini.rs`
+
+**Step 1: Implement Anthropic client**
+
+Replace the stub in `src/ai/providers/anthropic.rs`:
+
+```rust
+use async_trait::async_trait;
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+
+use super::{AiProvider, CompletionRequest};
+
+pub struct AnthropicClient {
+    pub api_key: String,
+    client: reqwest::Client,
+}
+
+impl AnthropicClient {
+    pub fn new(api_key: String) -> Self {
+        Self { api_key, client: reqwest::Client::new() }
+    }
+}
+
+#[derive(Serialize)]
+struct AnthropicRequest {
+    model: String,
+    max_tokens: u32,
+    system: String,
+    messages: Vec<AnthropicMessage>,
+}
+
+#[derive(Serialize)]
+struct AnthropicMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct AnthropicResponse {
+    content: Vec<AnthropicContent>,
+}
+
+#[derive(Deserialize)]
+struct AnthropicContent {
+    text: String,
+}
+
+#[async_trait]
+impl AiProvider for AnthropicClient {
+    async fn complete(&self, req: CompletionRequest, cancel: CancellationToken) -> Result<String> {
+        let mut messages: Vec<AnthropicMessage> = req.context.iter().map(|m| AnthropicMessage {
+            role: "user".to_string(),
+            content: m.to_chat_line(),
+        }).collect();
+
+        messages.push(AnthropicMessage {
+            role: "user".to_string(),
+            content: format!("Complete this message (reply with ONLY the completion): {}", req.partial_input),
+        });
+
+        let body = AnthropicRequest {
+            model: req.model.clone(),
+            max_tokens: 80,
+            system: req.system.clone(),
+            messages,
+        };
+
+        let request = self.client
+            .post("https://api.anthropic.com/v1/messages")
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .json(&body);
+
+        tokio::select! {
+            _ = cancel.cancelled() => Err(anyhow!("cancelled")),
+            res = request.send() => {
+                let resp: AnthropicResponse = res?.json().await?;
+                Ok(resp.content.into_iter().next()
+                    .map(|c| c.text.trim().to_string())
+                    .unwrap_or_default())
+            }
+        }
+    }
+}
+```
+
+**Step 2: Implement Gemini client**
+
+Replace the stub in `src/ai/providers/gemini.rs`:
+
+```rust
+use async_trait::async_trait;
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+
+use super::{AiProvider, CompletionRequest};
+
+pub struct GeminiClient {
+    pub api_key: String,
+    client: reqwest::Client,
+}
+
+impl GeminiClient {
+    pub fn new(api_key: String) -> Self {
+        Self { api_key, client: reqwest::Client::new() }
+    }
+}
+
+#[derive(Serialize)]
+struct GeminiRequest {
+    contents: Vec<GeminiContent>,
+    #[serde(rename = "systemInstruction")]
+    system_instruction: GeminiSystemInstruction,
+    #[serde(rename = "generationConfig")]
+    generation_config: GeminiGenerationConfig,
+}
+
+#[derive(Serialize)]
+struct GeminiContent {
+    parts: Vec<GeminiPart>,
+}
+
+#[derive(Serialize)]
+struct GeminiPart {
+    text: String,
+}
+
+#[derive(Serialize)]
+struct GeminiSystemInstruction {
+    parts: Vec<GeminiPart>,
+}
+
+#[derive(Serialize)]
+struct GeminiGenerationConfig {
+    #[serde(rename = "maxOutputTokens")]
+    max_output_tokens: u32,
+}
+
+#[derive(Deserialize)]
+struct GeminiResponse {
+    candidates: Vec<GeminiCandidate>,
+}
+
+#[derive(Deserialize)]
+struct GeminiCandidate {
+    content: GeminiCandidateContent,
+}
+
+#[derive(Deserialize)]
+struct GeminiCandidateContent {
+    parts: Vec<GeminiResponsePart>,
+}
+
+#[derive(Deserialize)]
+struct GeminiResponsePart {
+    text: String,
+}
+
+#[async_trait]
+impl AiProvider for GeminiClient {
+    async fn complete(&self, req: CompletionRequest, cancel: CancellationToken) -> Result<String> {
+        let mut text_parts: Vec<String> = req.context.iter()
+            .map(|m| m.to_chat_line())
+            .collect();
+        text_parts.push(format!("Complete this message (reply with ONLY the completion): {}", req.partial_input));
+
+        let contents = vec![GeminiContent {
+            parts: text_parts.into_iter().map(|t| GeminiPart { text: t }).collect(),
+        }];
+
+        let body = GeminiRequest {
+            system_instruction: GeminiSystemInstruction {
+                parts: vec![GeminiPart { text: req.system.clone() }],
+            },
+            contents,
+            generation_config: GeminiGenerationConfig { max_output_tokens: 80 },
+        };
+
+        let url = format!(
+            "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
+            req.model, self.api_key
+        );
+
+        let request = self.client.post(&url).json(&body);
+
+        tokio::select! {
+            _ = cancel.cancelled() => Err(anyhow!("cancelled")),
+            res = request.send() => {
+                let resp: GeminiResponse = res?.json().await?;
+                Ok(resp.candidates.into_iter().next()
+                    .and_then(|c| c.content.parts.into_iter().next())
+                    .map(|p| p.text.trim().to_string())
+                    .unwrap_or_default())
+            }
+        }
+    }
+}
+```
+
+**Step 3: Verify compilation**
+
+```bash
+cargo check
+```
+Expected: no errors.
+
+**Step 4: Commit**
+
+```bash
+git add src/ai/providers/anthropic.rs src/ai/providers/gemini.rs
+git commit -m "feat: add Anthropic and Gemini provider implementations"
+```
+
+---
+
+### Task 4: Context builder
+
+**Files:**
+- Modify: `src/ai/context.rs`
+
+**Step 1: Write unit tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::providers::MessageRole;
+
+    #[test]
+    fn builds_context_from_messages() {
+        let messages = vec![
+            RawMessage { is_outgoing: true,  text: "hey".to_string() },
+            RawMessage { is_outgoing: false, text: "yo".to_string() },
+        ];
+        let ctx = build_context(&messages, None, 10);
+        assert_eq!(ctx.len(), 2);
+        assert_eq!(ctx[0].to_chat_line(), "[You]: hey");
+        assert_eq!(ctx[1].to_chat_line(), "[Them]: yo");
+    }
+
+    #[test]
+    fn limits_to_last_n() {
+        let messages: Vec<RawMessage> = (0..20).map(|i| RawMessage {
+            is_outgoing: i % 2 == 0,
+            text: format!("msg {}", i),
+        }).collect();
+        let ctx = build_context(&messages, None, 5);
+        assert_eq!(ctx.len(), 5);
+        assert_eq!(ctx.last().unwrap().to_chat_line(), "[Them]: msg 19");
+    }
+
+    #[test]
+    fn prepends_summary_as_first_message() {
+        let messages = vec![
+            RawMessage { is_outgoing: true, text: "hi".to_string() },
+        ];
+        let ctx = build_context(&messages, Some("Chat about cats"), 10);
+        assert_eq!(ctx.len(), 2);
+        assert!(matches!(ctx[0].role, MessageRole::Assistant));
+        assert!(ctx[0].content.contains("cats"));
+    }
+}
+```
+
+**Step 2: Run to confirm failure**
+
+```bash
+cargo test ai::context
+```
+Expected: compile error.
+
+**Step 3: Implement `src/ai/context.rs`**
+
+```rust
+use crate::ai::providers::{ContextMessage, MessageRole};
+
+pub const SYSTEM_PROMPT: &str =
+    "You are a chat autocomplete assistant. Complete the user's message naturally \
+     based on the conversation context. Reply with ONLY the completion text — \
+     no explanation, no quotes, no prefix.";
+
+pub struct RawMessage {
+    pub is_outgoing: bool,
+    pub text: String,
+}
+
+/// Assemble context from optional summary + last N messages.
+pub fn build_context(
+    messages: &[RawMessage],
+    summary: Option<&str>,
+    last_n: usize,
+) -> Vec<ContextMessage> {
+    let mut ctx: Vec<ContextMessage> = Vec::new();
+
+    if let Some(s) = summary {
+        ctx.push(ContextMessage {
+            role: MessageRole::Assistant,
+            content: format!("[Conversation summary]: {}", s),
+        });
+    }
+
+    let start = messages.len().saturating_sub(last_n);
+    for msg in &messages[start..] {
+        ctx.push(ContextMessage {
+            role: if msg.is_outgoing { MessageRole::User } else { MessageRole::Assistant },
+            content: msg.text.clone(),
+        });
+    }
+
+    ctx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::providers::MessageRole;
+
+    #[test]
+    fn builds_context_from_messages() {
+        let messages = vec![
+            RawMessage { is_outgoing: true,  text: "hey".to_string() },
+            RawMessage { is_outgoing: false, text: "yo".to_string() },
+        ];
+        let ctx = build_context(&messages, None, 10);
+        assert_eq!(ctx.len(), 2);
+        assert_eq!(ctx[0].to_chat_line(), "[You]: hey");
+        assert_eq!(ctx[1].to_chat_line(), "[Them]: yo");
+    }
+
+    #[test]
+    fn limits_to_last_n() {
+        let messages: Vec<RawMessage> = (0..20).map(|i| RawMessage {
+            is_outgoing: i % 2 == 0,
+            text: format!("msg {}", i),
+        }).collect();
+        let ctx = build_context(&messages, None, 5);
+        assert_eq!(ctx.len(), 5);
+        assert_eq!(ctx.last().unwrap().to_chat_line(), "[Them]: msg 19");
+    }
+
+    #[test]
+    fn prepends_summary_as_first_message() {
+        let messages = vec![
+            RawMessage { is_outgoing: true, text: "hi".to_string() },
+        ];
+        let ctx = build_context(&messages, Some("Chat about cats"), 10);
+        assert_eq!(ctx.len(), 2);
+        assert!(matches!(ctx[0].role, MessageRole::Assistant));
+        assert!(ctx[0].content.contains("cats"));
+    }
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+cargo test ai::context
+```
+Expected: 3 tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/ai/context.rs
+git commit -m "feat: add AI context builder with summary support"
+```
+
+---
+
+### Task 5: AI Worker
+
+**Files:**
+- Modify: `src/ai/worker.rs`
+- Modify: `src/tui/event.rs`
+
+**Step 1: Add new `AppEvent` variants to `src/tui/event.rs`**
+
+In the `AppEvent` enum, add:
+
+```rust
+AiSuggestion(String),
+AiError(String),
+```
+
+Also expose a way to clone the sender so the worker can inject events. Add a field and method to `EventHandler`:
+
+```rust
+pub struct EventHandler {
+    rx: mpsc::UnboundedReceiver<AppEvent>,
+    pub tx: mpsc::UnboundedSender<AppEvent>,   // add this
+    _task: tokio::task::JoinHandle<()>,
+}
+```
+
+And expose it:
+```rust
+pub fn sender(&self) -> mpsc::UnboundedSender<AppEvent> {
+    self.tx.clone()
+}
+```
+
+In `EventHandler::new`, save `tx` before moving it into the spawned task — clone it first:
+
+```rust
+let (tx, rx) = mpsc::unbounded_channel::<AppEvent>();
+let task_tx = tx.clone();  // move task_tx into the spawn, keep tx on self
+// ... use task_tx inside the spawned task instead of tx
+Self { rx, tx, _task: task }
+```
+
+**Step 2: Implement `src/ai/worker.rs`**
+
+```rust
+use std::time::Duration;
+
+use anyhow::Result;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use crate::ai::context::{build_context, RawMessage, SYSTEM_PROMPT};
+use crate::ai::providers::{AiProvider, CompletionRequest};
+use crate::config::settings::AiConfig;
+use crate::tui::event::AppEvent;
+
+pub struct AiWorker {
+    provider: Box<dyn AiProvider>,
+    config: AiConfig,
+    event_tx: mpsc::UnboundedSender<AppEvent>,
+    cancel_token: Option<CancellationToken>,
+}
+
+pub struct AiRequest {
+    pub partial_input: String,
+    pub messages: Vec<RawMessage>,
+    pub summary: Option<String>,
+}
+
+impl AiWorker {
+    pub fn new(
+        provider: Box<dyn AiProvider>,
+        config: AiConfig,
+        event_tx: mpsc::UnboundedSender<AppEvent>,
+    ) -> Self {
+        Self { provider, config, event_tx, cancel_token: None }
+    }
+
+    /// Cancel any inflight request and fire a new one.
+    pub fn request(&mut self, req: AiRequest) {
+        // Cancel previous
+        if let Some(token) = self.cancel_token.take() {
+            token.cancel();
+        }
+
+        let token = CancellationToken::new();
+        self.cancel_token = Some(token.clone());
+
+        let provider = self.provider.clone_box();
+        let event_tx = self.event_tx.clone();
+        let model = self.config.model.clone();
+        let last_n = self.config.context_messages;
+
+        tokio::spawn(async move {
+            let context = build_context(&req.messages, req.summary.as_deref(), last_n);
+
+            let completion_req = CompletionRequest {
+                model,
+                system: SYSTEM_PROMPT.to_string(),
+                context,
+                partial_input: req.partial_input,
+            };
+
+            match provider.complete(completion_req, token).await {
+                Ok(text) if !text.is_empty() => {
+                    let _ = event_tx.send(AppEvent::AiSuggestion(text));
+                }
+                Err(e) if e.to_string() != "cancelled" => {
+                    let _ = event_tx.send(AppEvent::AiError(e.to_string()));
+                }
+                _ => {}
+            }
+        });
+    }
+}
+```
+
+**Step 3: Add `clone_box` to the `AiProvider` trait**
+
+In `src/ai/providers/mod.rs`, update the trait:
+
+```rust
+pub trait AiProvider: Send + Sync {
+    async fn complete(&self, req: CompletionRequest, cancel: CancellationToken) -> Result<String>;
+    fn clone_box(&self) -> Box<dyn AiProvider>;
+}
+```
+
+Implement `clone_box` on each provider by deriving `Clone` on the client structs and returning `Box::new(self.clone())`.
+
+For `OpenAiClient`, `AnthropicClient`, `GeminiClient` — add `#[derive(Clone)]` and:
+
+```rust
+fn clone_box(&self) -> Box<dyn AiProvider> {
+    Box::new(self.clone())
+}
+```
+
+Note: `reqwest::Client` is already `Clone` (it's an `Arc` internally).
+
+**Step 4: Verify compilation**
+
+```bash
+cargo check
+```
+Expected: no errors.
+
+**Step 5: Commit**
+
+```bash
+git add src/ai/worker.rs src/tui/event.rs src/ai/providers/
+git commit -m "feat: add AiWorker with cancellation token and AppEvent AI variants"
+```
+
+---
+
+### Task 6: Keybindings — Tab accept and Ctrl+Space trigger
+
+**Files:**
+- Modify: `src/tui/keybindings.rs`
+- Modify: `src/tui/app_state.rs`
+
+**Step 1: Add new `Action` variants to `src/tui/keybindings.rs`**
+
+In the `Action` enum, add:
+
+```rust
+AiSuggestAccept,   // Tab / → at end of input when suggestion present
+AiSuggestRequest,  // Ctrl+Space — on-demand trigger
+```
+
+**Step 2: Update `map_editing_mode` in `src/tui/keybindings.rs`**
+
+Add these arms before the catch-all `_ => Action::InputKey(key)`:
+
+```rust
+(KeyCode::Tab, _) => Action::AiSuggestAccept,
+(KeyCode::Char(' '), m) if m.contains(KeyModifiers::CONTROL) => Action::AiSuggestRequest,
+```
+
+**Step 3: Add `ai_suggestion` to `AppState`**
+
+In `src/tui/app_state.rs`, add to `AppState` struct:
+
+```rust
+pub ai_suggestion: Option<String>,
+pub ai_status: Option<String>,   // brief error message for status bar
+```
+
+Initialise both to `None` in `AppState::new()`.
+
+**Step 4: Verify compilation**
+
+```bash
+cargo check
+```
+Expected: no errors.
+
+**Step 5: Commit**
+
+```bash
+git add src/tui/keybindings.rs src/tui/app_state.rs
+git commit -m "feat: add AiSuggestAccept/Request actions and ai_suggestion state"
+```
+
+---
+
+### Task 7: Wire everything into `app.rs`
+
+**Files:**
+- Modify: `src/app.rs`
+
+**Step 1: Import new types**
+
+Add to imports in `src/app.rs`:
+
+```rust
+use crate::ai::worker::{AiWorker, AiRequest};
+use crate::ai::context::RawMessage;
+use crate::ai::providers::openai::OpenAiClient;
+use crate::ai::providers::anthropic::AnthropicClient;
+use crate::ai::providers::gemini::GeminiClient;
+use std::time::{Duration, Instant};
+```
+
+**Step 2: Add `AiWorker` and debounce fields to `App`**
+
+```rust
+pub struct App {
+    state: AppState,
+    router: MessageRouter,
+    db: Database,
+    address_book: AddressBook,
+    config: AppConfig,
+    config_path: PathBuf,
+    ai_worker: Option<AiWorker>,           // None when AI disabled
+    last_keystroke: Option<Instant>,        // for debounce tracking
+}
+```
+
+**Step 3: Initialise `AiWorker` in `App::new()`**
+
+After setting up `state`, create the worker if AI is enabled. The worker needs the event sender — pass it in:
+
+```rust
+pub fn new(
+    config: AppConfig,
+    db: Database,
+    address_book: AddressBook,
+    config_path: PathBuf,
+    event_tx: tokio::sync::mpsc::UnboundedSender<AppEvent>,
+) -> Self {
+    let ai_worker = if config.ai.enabled {
+        let provider: Box<dyn crate::ai::providers::AiProvider> = match config.ai.provider.as_str() {
+            "anthropic" => Box::new(AnthropicClient::new(config.ai.api_key.clone())),
+            "gemini"    => Box::new(GeminiClient::new(config.ai.api_key.clone())),
+            _           => Box::new(OpenAiClient::new(config.ai.base_url.clone(), config.ai.api_key.clone())),
+        };
+        Some(AiWorker::new(provider, config.ai.clone(), event_tx))
+    } else {
+        None
+    };
+
+    Self {
+        state: AppState::new(),
+        router: MessageRouter::new(),
+        db,
+        address_book,
+        config,
+        config_path,
+        ai_worker,
+        last_keystroke: None,
+    }
+}
+```
+
+**Step 4: Update `App::new()` call site in `src/main.rs`**
+
+In `main.rs`, after creating `EventHandler`, pass the sender to `App::new`:
+
+```rust
+let event_handler = EventHandler::new(config.tui.tick_rate_ms, config.tui.render_rate_ms);
+let app = App::new(config, db, address_book, config_path, event_handler.sender());
+```
+
+**Step 5: Handle debounce on `InputKey` events**
+
+In the `Action::InputKey` arm of the event handler loop in `app.rs`, after forwarding the key to textarea, add:
+
+```rust
+// Dismiss any existing suggestion on new keystroke
+self.state.ai_suggestion = None;
+// Record keystroke time for debounce
+self.last_keystroke = Some(Instant::now());
+```
+
+**Step 6: Handle debounce firing on `AppEvent::Tick`**
+
+In the `AppEvent::Tick` arm, add:
+
+```rust
+if let (Some(t), Some(worker)) = (self.last_keystroke, self.ai_worker.as_mut()) {
+    let debounce = Duration::from_millis(self.config.ai.debounce_ms);
+    if t.elapsed() >= debounce {
+        self.last_keystroke = None;
+        if self.state.input_mode == InputMode::Editing {
+            let partial = self.state.input.lines().join("\n");
+            if !partial.is_empty() {
+                self.fire_ai_request(worker, partial);
+            }
+        }
+    }
+}
+```
+
+**Step 7: Add `fire_ai_request` helper method**
+
+```rust
+fn fire_ai_request(&self, worker: &mut AiWorker, partial: String) {
+    let messages = self.state.messages.iter()
+        .map(|m| {
+            let text = match &m.content {
+                crate::core::types::MessageContent::Text(t) => t.clone(),
+                _ => String::new(),
+            };
+            RawMessage { is_outgoing: m.is_outgoing, text }
+        })
+        .filter(|m| !m.text.is_empty())
+        .collect();
+
+    let summary = self.state.selected_chat_id()
+        .and_then(|id| self.db.get_preference(&format!("ai_summary:{}", id)).ok().flatten());
+
+    worker.request(AiRequest { partial_input: partial, messages, summary });
+}
+```
+
+**Step 8: Handle AI events in the main match**
+
+```rust
+AppEvent::AiSuggestion(text) => {
+    if self.state.input_mode == InputMode::Editing {
+        self.state.ai_suggestion = Some(text);
+    }
+}
+AppEvent::AiError(e) => {
+    self.state.ai_status = Some(format!("AI: {}", e));
+}
+```
+
+**Step 9: Handle `Action::AiSuggestAccept`**
+
+```rust
+Action::AiSuggestAccept => {
+    if let Some(suggestion) = self.state.ai_suggestion.take() {
+        // Append suggestion text to the textarea
+        for ch in suggestion.chars() {
+            self.state.input.insert_char(ch);
+        }
+    } else {
+        // No suggestion — forward Tab as literal tab or ignore
+    }
+}
+```
+
+**Step 10: Handle `Action::AiSuggestRequest`**
+
+```rust
+Action::AiSuggestRequest => {
+    if self.state.input_mode == InputMode::Editing {
+        let partial = self.state.input.lines().join("\n");
+        if !partial.is_empty() {
+            if let Some(worker) = self.ai_worker.as_mut() {
+                self.fire_ai_request(worker, partial);
+            }
+        }
+    }
+}
+```
+
+**Step 11: Clear suggestion on mode exit**
+
+In the `Action::ExitEditing` arm, add:
+
+```rust
+self.state.ai_suggestion = None;
+```
+
+**Step 12: Verify compilation**
+
+```bash
+cargo check
+```
+Expected: no errors.
+
+**Step 13: Commit**
+
+```bash
+git add src/app.rs src/main.rs
+git commit -m "feat: wire AiWorker into app event loop with debounce and key actions"
+```
+
+---
+
+### Task 8: Ghost text rendering in input bar
+
+**Files:**
+- Modify: `src/tui/widgets/input_bar.rs`
+- Modify: `src/tui/render.rs`
+
+**Step 1: Update `render_input_bar` signature**
+
+In `src/tui/widgets/input_bar.rs`, change the function signature to accept the suggestion:
+
+```rust
+pub fn render_input_bar(
+    f: &mut Frame,
+    area: Rect,
+    textarea: &TextArea<'static>,
+    mode: InputMode,
+    ai_suggestion: Option<&str>,
+) {
+```
+
+**Step 2: Render ghost text**
+
+Inside the `if mode == InputMode::Editing` branch, after rendering the textarea widget, add:
+
+```rust
+// Render ghost text if suggestion present
+if let Some(suggestion) = ai_suggestion {
+    // Position ghost text after the cursor on the last line
+    let lines = textarea.lines();
+    let last_line = lines.last().map(|l| l.len()).unwrap_or(0);
+
+    // Ghost text appears on a line below the input if input takes full width,
+    // or we show it as a styled paragraph overlaid in the hint area.
+    // Simple approach: show hint line at bottom of inner_area.
+    let hint_area = Rect {
+        x: inner_area.x,
+        y: inner_area.y + inner_area.height.saturating_sub(1),
+        width: inner_area.width,
+        height: 1,
+    };
+    let hint_text = format!("  ↳ {}", suggestion);
+    f.render_widget(
+        Paragraph::new(hint_text)
+            .style(Style::default().fg(Color::DarkGray)),
+        hint_area,
+    );
+}
+```
+
+Note: This renders the ghost text as a greyed hint line at the bottom of the input area. A full inline ghost-text (same line as cursor) requires custom rendering beyond what `tui-textarea` exposes; the hint-line approach is clean and unambiguous for a TUI.
+
+**Step 3: Update call site in `src/tui/render.rs`**
+
+Find the call to `render_input_bar` and add `state.ai_suggestion.as_deref()` as the last argument.
+
+**Step 4: Verify compilation**
+
+```bash
+cargo check
+```
+Expected: no errors.
+
+**Step 5: Manual smoke test**
+
+```bash
+cargo run
+```
+
+- Enable AI in `configs/default.toml` (`enabled = true`, ensure Ollama is running with `qwen2.5:1.5b-instruct`)
+- Open a chat, press `i` to enter INSERT mode
+- Type a partial message and wait ~500ms
+- Verify a greyed hint line appears below the input
+- Press `Tab` to accept — text should be appended
+- Press `Ctrl+Space` to trigger on demand
+
+**Step 6: Commit**
+
+```bash
+git add src/tui/widgets/input_bar.rs src/tui/render.rs
+git commit -m "feat: render AI autocomplete ghost text hint in input bar"
+```
+
+---
+
+### Task 9: Summary generation (background task)
+
+**Files:**
+- Modify: `src/ai/worker.rs`
+- Modify: `src/app.rs`
+
+**Step 1: Add summary generation method to `AiWorker`**
+
+In `src/ai/worker.rs`, add:
+
+```rust
+pub fn maybe_generate_summary(
+    &self,
+    chat_id: String,
+    messages: Vec<RawMessage>,
+    threshold: usize,
+    db_tx: mpsc::UnboundedSender<(String, String)>,  // (pref_key, value)
+) {
+    if messages.len() < threshold {
+        return;
+    }
+
+    let provider = self.provider.clone_box();
+    let model = self.config.model.clone();
+
+    tokio::spawn(async move {
+        // Summarise first (messages.len() - threshold/2) messages
+        let older: Vec<String> = messages.iter()
+            .take(messages.len() - threshold / 2)
+            .map(|m| m.to_chat_line_owned())
+            .collect();
+
+        let prompt = format!(
+            "Summarise this conversation in 2-3 sentences:\n\n{}",
+            older.join("\n")
+        );
+
+        let req = CompletionRequest {
+            model,
+            system: "You summarise conversations concisely.".to_string(),
+            context: vec![],
+            partial_input: prompt,
+        };
+
+        let cancel = CancellationToken::new();
+        if let Ok(summary) = provider.complete(req, cancel).await {
+            let key = format!("ai_summary:{}", chat_id);
+            let _ = db_tx.send((key, summary));
+        }
+    });
+}
+```
+
+Add `fn to_chat_line_owned(&self) -> String` to `RawMessage`:
+
+```rust
+impl RawMessage {
+    pub fn to_chat_line_owned(&self) -> String {
+        if self.is_outgoing { format!("[You]: {}", self.text) }
+        else { format!("[Them]: {}", self.text) }
+    }
+}
+```
+
+**Step 2: Wire summary saves in `app.rs`**
+
+When a new message arrives for the active chat (in the `ProviderEvent::Message` handler), check the message count and fire `maybe_generate_summary` if threshold is crossed. Save responses from `db_tx` by adding a `db_rx` channel and polling it in the Tick handler.
+
+This is a non-blocking background operation — failures are silent (summary is optional).
+
+**Step 3: Verify compilation**
+
+```bash
+cargo check
+```
+Expected: no errors.
+
+**Step 4: Commit**
+
+```bash
+git add src/ai/worker.rs src/app.rs
+git commit -m "feat: background summary generation stored in preferences"
+```
+
+---
+
+### Task 10: Final verification
+
+**Step 1: Run all tests**
+
+```bash
+cargo test
+```
+Expected: all pass.
+
+**Step 2: Build release binary**
+
+```bash
+cargo build --release
+```
+Expected: success.
+
+**Step 3: End-to-end smoke test with Ollama**
+
+```bash
+# Ensure Ollama is running and model is pulled:
+ollama pull qwen2.5:1.5b-instruct
+
+# Enable AI in config
+# Set [ai] enabled = true in configs/default.toml
+
+./target/release/zero-drift-chat
+```
+
+Checklist:
+- [ ] App starts normally when `ai.enabled = false`
+- [ ] App starts and connects to Ollama when `ai.enabled = true`
+- [ ] Typing in INSERT mode → ghost hint appears after debounce
+- [ ] `Ctrl+Space` triggers immediately
+- [ ] `Tab` accepts suggestion
+- [ ] `Esc` dismisses suggestion and exits INSERT mode
+- [ ] Any other key dismisses suggestion and continues editing
+- [ ] AI errors show briefly (non-fatal)
+
+**Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: AI autocomplete — ghost text, debounce, multi-provider support"
+```

--- a/src/ai/context.rs
+++ b/src/ai/context.rs
@@ -1,0 +1,1 @@
+// Stub — implemented in Task 4

--- a/src/ai/context.rs
+++ b/src/ai/context.rs
@@ -10,6 +10,16 @@ pub struct RawMessage {
     pub text: String,
 }
 
+impl RawMessage {
+    pub fn to_chat_line_owned(&self) -> String {
+        if self.is_outgoing {
+            format!("[You]: {}", self.text)
+        } else {
+            format!("[Them]: {}", self.text)
+        }
+    }
+}
+
 /// Assemble context from optional summary + last N messages.
 pub fn build_context(
     messages: &[RawMessage],

--- a/src/ai/context.rs
+++ b/src/ai/context.rs
@@ -1,9 +1,12 @@
 use crate::ai::providers::{ContextMessage, MessageRole};
 
 pub const SYSTEM_PROMPT: &str =
-    "You are a chat autocomplete assistant. Complete the user's message naturally \
-     based on the conversation context. Reply with ONLY the completion text — \
-     no explanation, no quotes, no prefix.";
+    "You predict the next few words to complete the sender's unfinished chat message. \
+     Look at their past messages (labeled [You]) to learn their writing style, tone, and vocabulary. \
+     Complete only their current partial message — do not write what the other person would say, \
+     do not start a new thought, do not add ideas they didn't begin. \
+     Reply with ONLY the short completion (a few words to finish the sentence they started). \
+     No explanation. No quotes. No punctuation prefix.";
 
 pub struct RawMessage {
     pub is_outgoing: bool,

--- a/src/ai/context.rs
+++ b/src/ai/context.rs
@@ -39,7 +39,6 @@ pub fn build_context(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ai::providers::MessageRole;
 
     #[test]
     fn builds_context_from_messages() {

--- a/src/ai/context.rs
+++ b/src/ai/context.rs
@@ -1,1 +1,77 @@
-// Stub — implemented in Task 4
+use crate::ai::providers::{ContextMessage, MessageRole};
+
+pub const SYSTEM_PROMPT: &str =
+    "You are a chat autocomplete assistant. Complete the user's message naturally \
+     based on the conversation context. Reply with ONLY the completion text — \
+     no explanation, no quotes, no prefix.";
+
+pub struct RawMessage {
+    pub is_outgoing: bool,
+    pub text: String,
+}
+
+/// Assemble context from optional summary + last N messages.
+pub fn build_context(
+    messages: &[RawMessage],
+    summary: Option<&str>,
+    last_n: usize,
+) -> Vec<ContextMessage> {
+    let mut ctx: Vec<ContextMessage> = Vec::new();
+
+    if let Some(s) = summary {
+        ctx.push(ContextMessage {
+            role: MessageRole::Assistant,
+            content: format!("[Conversation summary]: {}", s),
+        });
+    }
+
+    let start = messages.len().saturating_sub(last_n);
+    for msg in &messages[start..] {
+        ctx.push(ContextMessage {
+            role: if msg.is_outgoing { MessageRole::User } else { MessageRole::Assistant },
+            content: msg.text.clone(),
+        });
+    }
+
+    ctx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::providers::MessageRole;
+
+    #[test]
+    fn builds_context_from_messages() {
+        let messages = vec![
+            RawMessage { is_outgoing: true,  text: "hey".to_string() },
+            RawMessage { is_outgoing: false, text: "yo".to_string() },
+        ];
+        let ctx = build_context(&messages, None, 10);
+        assert_eq!(ctx.len(), 2);
+        assert_eq!(ctx[0].to_chat_line(), "[You]: hey");
+        assert_eq!(ctx[1].to_chat_line(), "[Them]: yo");
+    }
+
+    #[test]
+    fn limits_to_last_n() {
+        let messages: Vec<RawMessage> = (0..20).map(|i| RawMessage {
+            is_outgoing: i % 2 == 0,
+            text: format!("msg {}", i),
+        }).collect();
+        let ctx = build_context(&messages, None, 5);
+        assert_eq!(ctx.len(), 5);
+        assert_eq!(ctx.last().unwrap().to_chat_line(), "[Them]: msg 19");
+    }
+
+    #[test]
+    fn prepends_summary_as_first_message() {
+        let messages = vec![
+            RawMessage { is_outgoing: true, text: "hi".to_string() },
+        ];
+        let ctx = build_context(&messages, Some("Chat about cats"), 10);
+        assert_eq!(ctx.len(), 2);
+        assert!(matches!(ctx[0].role, MessageRole::Assistant));
+        assert!(ctx[0].content.contains("cats"));
+    }
+}

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -1,0 +1,3 @@
+pub mod providers;
+pub mod context;
+pub mod worker;

--- a/src/ai/providers/anthropic.rs
+++ b/src/ai/providers/anthropic.rs
@@ -1,0 +1,28 @@
+use async_trait::async_trait;
+use anyhow::Result;
+use tokio_util::sync::CancellationToken;
+
+use super::{AiProvider, CompletionRequest};
+
+#[derive(Clone)]
+pub struct AnthropicClient {
+    pub api_key: Option<String>,
+    client: reqwest::Client,
+}
+
+impl AnthropicClient {
+    pub fn new(api_key: Option<String>) -> Self {
+        Self { api_key, client: reqwest::Client::new() }
+    }
+}
+
+#[async_trait]
+impl AiProvider for AnthropicClient {
+    async fn complete(&self, _req: CompletionRequest, _cancel: CancellationToken) -> Result<String> {
+        anyhow::bail!("Anthropic provider not yet implemented")
+    }
+
+    fn clone_box(&self) -> Box<dyn AiProvider> {
+        Box::new(self.clone())
+    }
+}

--- a/src/ai/providers/anthropic.rs
+++ b/src/ai/providers/anthropic.rs
@@ -44,7 +44,9 @@ struct AnthropicContent {
 #[async_trait]
 impl AiProvider for AnthropicClient {
     async fn complete(&self, req: CompletionRequest, cancel: CancellationToken) -> Result<String> {
-        let api_key = self.api_key.as_deref().unwrap_or_default();
+        let api_key = self.api_key.as_deref()
+            .filter(|k| !k.is_empty())
+            .ok_or_else(|| anyhow!("Anthropic API key not configured"))?;
 
         let mut messages: Vec<AnthropicMessage> = req.context.iter().map(|m| {
             let role = match m.role {
@@ -78,7 +80,7 @@ impl AiProvider for AnthropicClient {
         tokio::select! {
             _ = cancel.cancelled() => Err(anyhow!("cancelled")),
             res = request.send() => {
-                let resp: AnthropicResponse = res?.json().await?;
+                let resp: AnthropicResponse = res?.error_for_status()?.json().await?;
                 Ok(resp.content.into_iter().next()
                     .map(|c| c.text.trim().to_string())
                     .unwrap_or_default())

--- a/src/ai/providers/anthropic.rs
+++ b/src/ai/providers/anthropic.rs
@@ -1,8 +1,9 @@
 use async_trait::async_trait;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
-use super::{AiProvider, CompletionRequest};
+use super::{AiProvider, CompletionRequest, MessageRole};
 
 #[derive(Clone)]
 pub struct AnthropicClient {
@@ -16,10 +17,73 @@ impl AnthropicClient {
     }
 }
 
+#[derive(Serialize)]
+struct AnthropicRequest {
+    model: String,
+    max_tokens: u32,
+    system: String,
+    messages: Vec<AnthropicMessage>,
+}
+
+#[derive(Serialize)]
+struct AnthropicMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct AnthropicResponse {
+    content: Vec<AnthropicContent>,
+}
+
+#[derive(Deserialize)]
+struct AnthropicContent {
+    text: String,
+}
+
 #[async_trait]
 impl AiProvider for AnthropicClient {
-    async fn complete(&self, _req: CompletionRequest, _cancel: CancellationToken) -> Result<String> {
-        anyhow::bail!("Anthropic provider not yet implemented")
+    async fn complete(&self, req: CompletionRequest, cancel: CancellationToken) -> Result<String> {
+        let api_key = self.api_key.as_deref().unwrap_or_default();
+
+        let mut messages: Vec<AnthropicMessage> = req.context.iter().map(|m| {
+            let role = match m.role {
+                MessageRole::User => "user",
+                MessageRole::Assistant => "assistant",
+            };
+            AnthropicMessage {
+                role: role.to_string(),
+                content: m.content.clone(),
+            }
+        }).collect();
+
+        messages.push(AnthropicMessage {
+            role: "user".to_string(),
+            content: format!("Complete this message (reply with ONLY the completion): {}", req.partial_input),
+        });
+
+        let body = AnthropicRequest {
+            model: req.model.clone(),
+            max_tokens: 80,
+            system: req.system.clone(),
+            messages,
+        };
+
+        let request = self.client
+            .post("https://api.anthropic.com/v1/messages")
+            .header("x-api-key", api_key)
+            .header("anthropic-version", "2023-06-01")
+            .json(&body);
+
+        tokio::select! {
+            _ = cancel.cancelled() => Err(anyhow!("cancelled")),
+            res = request.send() => {
+                let resp: AnthropicResponse = res?.json().await?;
+                Ok(resp.content.into_iter().next()
+                    .map(|c| c.text.trim().to_string())
+                    .unwrap_or_default())
+            }
+        }
     }
 
     fn clone_box(&self) -> Box<dyn AiProvider> {

--- a/src/ai/providers/gemini.rs
+++ b/src/ai/providers/gemini.rs
@@ -1,8 +1,9 @@
 use async_trait::async_trait;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
-use super::{AiProvider, CompletionRequest};
+use super::{AiProvider, CompletionRequest, MessageRole};
 
 #[derive(Clone)]
 pub struct GeminiClient {
@@ -16,10 +17,105 @@ impl GeminiClient {
     }
 }
 
+#[derive(Serialize)]
+struct GeminiRequest {
+    contents: Vec<GeminiContent>,
+    #[serde(rename = "systemInstruction")]
+    system_instruction: GeminiSystemInstruction,
+    #[serde(rename = "generationConfig")]
+    generation_config: GeminiGenerationConfig,
+}
+
+#[derive(Serialize)]
+struct GeminiContent {
+    role: String,
+    parts: Vec<GeminiPart>,
+}
+
+#[derive(Serialize)]
+struct GeminiPart {
+    text: String,
+}
+
+#[derive(Serialize)]
+struct GeminiSystemInstruction {
+    parts: Vec<GeminiPart>,
+}
+
+#[derive(Serialize)]
+struct GeminiGenerationConfig {
+    #[serde(rename = "maxOutputTokens")]
+    max_output_tokens: u32,
+}
+
+#[derive(Deserialize)]
+struct GeminiResponse {
+    candidates: Vec<GeminiCandidate>,
+}
+
+#[derive(Deserialize)]
+struct GeminiCandidate {
+    content: GeminiCandidateContent,
+}
+
+#[derive(Deserialize)]
+struct GeminiCandidateContent {
+    parts: Vec<GeminiResponsePart>,
+}
+
+#[derive(Deserialize)]
+struct GeminiResponsePart {
+    text: String,
+}
+
 #[async_trait]
 impl AiProvider for GeminiClient {
-    async fn complete(&self, _req: CompletionRequest, _cancel: CancellationToken) -> Result<String> {
-        anyhow::bail!("Gemini provider not yet implemented")
+    async fn complete(&self, req: CompletionRequest, cancel: CancellationToken) -> Result<String> {
+        let api_key = self.api_key.as_deref().unwrap_or_default();
+
+        let mut contents: Vec<GeminiContent> = req.context.iter().map(|m| {
+            let role = match m.role {
+                MessageRole::User => "user",
+                MessageRole::Assistant => "model",
+            };
+            GeminiContent {
+                role: role.to_string(),
+                parts: vec![GeminiPart { text: m.content.clone() }],
+            }
+        }).collect();
+
+        contents.push(GeminiContent {
+            role: "user".to_string(),
+            parts: vec![GeminiPart {
+                text: format!("Complete this message (reply with ONLY the completion): {}", req.partial_input),
+            }],
+        });
+
+        let body = GeminiRequest {
+            system_instruction: GeminiSystemInstruction {
+                parts: vec![GeminiPart { text: req.system.clone() }],
+            },
+            contents,
+            generation_config: GeminiGenerationConfig { max_output_tokens: 80 },
+        };
+
+        let url = format!(
+            "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
+            req.model, api_key
+        );
+
+        let request = self.client.post(&url).json(&body);
+
+        tokio::select! {
+            _ = cancel.cancelled() => Err(anyhow!("cancelled")),
+            res = request.send() => {
+                let resp: GeminiResponse = res?.json().await?;
+                Ok(resp.candidates.into_iter().next()
+                    .and_then(|c| c.content.parts.into_iter().next())
+                    .map(|p| p.text.trim().to_string())
+                    .unwrap_or_default())
+            }
+        }
     }
 
     fn clone_box(&self) -> Box<dyn AiProvider> {

--- a/src/ai/providers/gemini.rs
+++ b/src/ai/providers/gemini.rs
@@ -71,7 +71,9 @@ struct GeminiResponsePart {
 #[async_trait]
 impl AiProvider for GeminiClient {
     async fn complete(&self, req: CompletionRequest, cancel: CancellationToken) -> Result<String> {
-        let api_key = self.api_key.as_deref().unwrap_or_default();
+        let api_key = self.api_key.as_deref()
+            .filter(|k| !k.is_empty())
+            .ok_or_else(|| anyhow!("Gemini API key not configured"))?;
 
         let mut contents: Vec<GeminiContent> = req.context.iter().map(|m| {
             let role = match m.role {
@@ -109,7 +111,7 @@ impl AiProvider for GeminiClient {
         tokio::select! {
             _ = cancel.cancelled() => Err(anyhow!("cancelled")),
             res = request.send() => {
-                let resp: GeminiResponse = res?.json().await?;
+                let resp: GeminiResponse = res?.error_for_status()?.json().await?;
                 Ok(resp.candidates.into_iter().next()
                     .and_then(|c| c.content.parts.into_iter().next())
                     .map(|p| p.text.trim().to_string())

--- a/src/ai/providers/gemini.rs
+++ b/src/ai/providers/gemini.rs
@@ -1,0 +1,28 @@
+use async_trait::async_trait;
+use anyhow::Result;
+use tokio_util::sync::CancellationToken;
+
+use super::{AiProvider, CompletionRequest};
+
+#[derive(Clone)]
+pub struct GeminiClient {
+    pub api_key: Option<String>,
+    client: reqwest::Client,
+}
+
+impl GeminiClient {
+    pub fn new(api_key: Option<String>) -> Self {
+        Self { api_key, client: reqwest::Client::new() }
+    }
+}
+
+#[async_trait]
+impl AiProvider for GeminiClient {
+    async fn complete(&self, _req: CompletionRequest, _cancel: CancellationToken) -> Result<String> {
+        anyhow::bail!("Gemini provider not yet implemented")
+    }
+
+    fn clone_box(&self) -> Box<dyn AiProvider> {
+        Box::new(self.clone())
+    }
+}

--- a/src/ai/providers/mod.rs
+++ b/src/ai/providers/mod.rs
@@ -1,0 +1,59 @@
+use async_trait::async_trait;
+use anyhow::Result;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone)]
+pub enum MessageRole {
+    User,
+    Assistant,
+}
+
+#[derive(Debug, Clone)]
+pub struct ContextMessage {
+    pub role: MessageRole,
+    pub content: String,
+}
+
+impl ContextMessage {
+    pub fn to_chat_line(&self) -> String {
+        match self.role {
+            MessageRole::User => format!("[You]: {}", self.content),
+            MessageRole::Assistant => format!("[Them]: {}", self.content),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CompletionRequest {
+    pub model: String,
+    pub system: String,
+    pub context: Vec<ContextMessage>,
+    pub partial_input: String,
+}
+
+#[async_trait]
+pub trait AiProvider: Send + Sync {
+    async fn complete(&self, req: CompletionRequest, cancel: CancellationToken) -> Result<String>;
+    fn clone_box(&self) -> Box<dyn AiProvider>;
+}
+
+pub mod openai;
+pub mod anthropic;
+pub mod gemini;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_message_display_outgoing() {
+        let msg = ContextMessage { role: MessageRole::User, content: "hello".to_string() };
+        assert_eq!(msg.to_chat_line(), "[You]: hello");
+    }
+
+    #[test]
+    fn context_message_display_incoming() {
+        let msg = ContextMessage { role: MessageRole::Assistant, content: "hi".to_string() };
+        assert_eq!(msg.to_chat_line(), "[Them]: hi");
+    }
+}

--- a/src/ai/providers/openai.rs
+++ b/src/ai/providers/openai.rs
@@ -58,26 +58,34 @@ impl AiProvider for OpenAiClient {
             ChatMessage { role: "system".to_string(), content: req.system.clone() },
         ];
 
-        for ctx_msg in &req.context {
-            let role = match ctx_msg.role {
-                MessageRole::User => "user",
-                MessageRole::Assistant => "assistant",
-            };
+        // Build a single context block so the AI sees [You]/[Them] labels clearly
+        if !req.context.is_empty() {
+            let history: String = req.context.iter().map(|m| {
+                let label = match m.role {
+                    MessageRole::User => "[You]",
+                    MessageRole::Assistant => "[Them]",
+                };
+                format!("{}: {}", label, m.content)
+            }).collect::<Vec<_>>().join("\n");
             messages.push(ChatMessage {
-                role: role.to_string(),
-                content: ctx_msg.content.clone(),
+                role: "user".to_string(),
+                content: format!("Conversation history:\n{}", history),
+            });
+            messages.push(ChatMessage {
+                role: "assistant".to_string(),
+                content: "Understood. I'll complete messages in the sender's style.".to_string(),
             });
         }
 
         messages.push(ChatMessage {
             role: "user".to_string(),
-            content: format!("Complete this message (reply with ONLY the completion, nothing else): {}", req.partial_input),
+            content: format!("Complete only the end of this message I'm typing (a few words max): {}", req.partial_input),
         });
 
         let body = ChatRequest {
             model: req.model.clone(),
             messages,
-            max_tokens: 80,
+            max_tokens: 30,
             stream: false,
         };
 

--- a/src/ai/providers/openai.rs
+++ b/src/ai/providers/openai.rs
@@ -1,0 +1,102 @@
+use async_trait::async_trait;
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+
+use super::{AiProvider, CompletionRequest};
+
+#[derive(Clone)]
+pub struct OpenAiClient {
+    pub base_url: String,
+    pub api_key: Option<String>,
+    client: reqwest::Client,
+}
+
+impl OpenAiClient {
+    pub fn new(base_url: String, api_key: Option<String>) -> Self {
+        Self {
+            base_url,
+            api_key,
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ChatMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Serialize)]
+struct ChatRequest {
+    model: String,
+    messages: Vec<ChatMessage>,
+    max_tokens: u32,
+    stream: bool,
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<Choice>,
+}
+
+#[derive(Deserialize)]
+struct Choice {
+    message: ChoiceMessage,
+}
+
+#[derive(Deserialize)]
+struct ChoiceMessage {
+    content: String,
+}
+
+#[async_trait]
+impl AiProvider for OpenAiClient {
+    async fn complete(&self, req: CompletionRequest, cancel: CancellationToken) -> Result<String> {
+        let mut messages = vec![
+            ChatMessage { role: "system".to_string(), content: req.system.clone() },
+        ];
+
+        for ctx_msg in &req.context {
+            messages.push(ChatMessage {
+                role: "user".to_string(),
+                content: ctx_msg.to_chat_line(),
+            });
+        }
+
+        messages.push(ChatMessage {
+            role: "user".to_string(),
+            content: format!("Complete this message (reply with ONLY the completion, nothing else): {}", req.partial_input),
+        });
+
+        let body = ChatRequest {
+            model: req.model.clone(),
+            messages,
+            max_tokens: 80,
+            stream: false,
+        };
+
+        let mut builder = self.client
+            .post(format!("{}/v1/chat/completions", self.base_url))
+            .json(&body);
+
+        if let Some(key) = &self.api_key {
+            builder = builder.bearer_auth(key);
+        }
+
+        tokio::select! {
+            _ = cancel.cancelled() => Err(anyhow!("cancelled")),
+            res = builder.send() => {
+                let resp: ChatResponse = res?.json().await?;
+                Ok(resp.choices.into_iter().next()
+                    .map(|c| c.message.content.trim().to_string())
+                    .unwrap_or_default())
+            }
+        }
+    }
+
+    fn clone_box(&self) -> Box<dyn AiProvider> {
+        Box::new(self.clone())
+    }
+}

--- a/src/ai/providers/openai.rs
+++ b/src/ai/providers/openai.rs
@@ -59,9 +59,13 @@ impl AiProvider for OpenAiClient {
         ];
 
         for ctx_msg in &req.context {
+            let role = match ctx_msg.role {
+                crate::ai::providers::MessageRole::User => "user",
+                crate::ai::providers::MessageRole::Assistant => "assistant",
+            };
             messages.push(ChatMessage {
-                role: "user".to_string(),
-                content: ctx_msg.to_chat_line(),
+                role: role.to_string(),
+                content: ctx_msg.content.clone(),
             });
         }
 

--- a/src/ai/providers/openai.rs
+++ b/src/ai/providers/openai.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
-use super::{AiProvider, CompletionRequest};
+use super::{AiProvider, CompletionRequest, MessageRole};
 
 #[derive(Clone)]
 pub struct OpenAiClient {
@@ -60,8 +60,8 @@ impl AiProvider for OpenAiClient {
 
         for ctx_msg in &req.context {
             let role = match ctx_msg.role {
-                crate::ai::providers::MessageRole::User => "user",
-                crate::ai::providers::MessageRole::Assistant => "assistant",
+                MessageRole::User => "user",
+                MessageRole::Assistant => "assistant",
             };
             messages.push(ChatMessage {
                 role: role.to_string(),
@@ -92,7 +92,7 @@ impl AiProvider for OpenAiClient {
         tokio::select! {
             _ = cancel.cancelled() => Err(anyhow!("cancelled")),
             res = builder.send() => {
-                let resp: ChatResponse = res?.json().await?;
+                let resp: ChatResponse = res?.error_for_status()?.json().await?;
                 Ok(resp.choices.into_iter().next()
                     .map(|c| c.message.content.trim().to_string())
                     .unwrap_or_default())

--- a/src/ai/worker.rs
+++ b/src/ai/worker.rs
@@ -1,0 +1,1 @@
+// Stub — implemented in Task 5

--- a/src/ai/worker.rs
+++ b/src/ai/worker.rs
@@ -28,6 +28,56 @@ impl AiWorker {
         Self { provider, config, event_tx, cancel_token: None }
     }
 
+    /// If messages exceed the threshold, asynchronously generate a summary
+    /// and send the (key, value) pair to be stored in preferences DB.
+    pub fn maybe_generate_summary(
+        &self,
+        chat_id: String,
+        messages: Vec<crate::ai::context::RawMessage>,
+        threshold: usize,
+        db_tx: tokio::sync::mpsc::UnboundedSender<(String, String)>,
+    ) {
+        if messages.len() < threshold {
+            return;
+        }
+
+        let provider = self.provider.clone_box();
+        let model = self.config.model.clone();
+
+        tokio::spawn(async move {
+            // Summarise the older portion (everything except the last threshold/2 messages)
+            let keep_recent = threshold / 2;
+            let older: Vec<String> = messages.iter()
+                .take(messages.len().saturating_sub(keep_recent))
+                .map(|m| m.to_chat_line_owned())
+                .collect();
+
+            if older.is_empty() {
+                return;
+            }
+
+            let prompt = format!(
+                "Summarise this conversation in 2-3 sentences:\n\n{}",
+                older.join("\n")
+            );
+
+            let req = crate::ai::providers::CompletionRequest {
+                model,
+                system: "You summarise conversations concisely.".to_string(),
+                context: vec![],
+                partial_input: prompt,
+            };
+
+            let cancel = tokio_util::sync::CancellationToken::new();
+            if let Ok(summary) = provider.complete(req, cancel).await {
+                if !summary.is_empty() {
+                    let key = format!("ai_summary:{}", chat_id);
+                    let _ = db_tx.send((key, summary));
+                }
+            }
+        });
+    }
+
     /// Cancel any inflight request and fire a new one.
     pub fn request(&mut self, req: AiRequest) {
         // Cancel previous inflight request

--- a/src/ai/worker.rs
+++ b/src/ai/worker.rs
@@ -1,1 +1,67 @@
-// Stub — implemented in Task 5
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use crate::ai::context::{build_context, RawMessage, SYSTEM_PROMPT};
+use crate::ai::providers::{AiProvider, CompletionRequest};
+use crate::config::settings::AiConfig;
+use crate::tui::event::AppEvent;
+
+pub struct AiWorker {
+    provider: Box<dyn AiProvider>,
+    config: AiConfig,
+    event_tx: mpsc::UnboundedSender<AppEvent>,
+    cancel_token: Option<CancellationToken>,
+}
+
+pub struct AiRequest {
+    pub partial_input: String,
+    pub messages: Vec<RawMessage>,
+    pub summary: Option<String>,
+}
+
+impl AiWorker {
+    pub fn new(
+        provider: Box<dyn AiProvider>,
+        config: AiConfig,
+        event_tx: mpsc::UnboundedSender<AppEvent>,
+    ) -> Self {
+        Self { provider, config, event_tx, cancel_token: None }
+    }
+
+    /// Cancel any inflight request and fire a new one.
+    pub fn request(&mut self, req: AiRequest) {
+        // Cancel previous inflight request
+        if let Some(token) = self.cancel_token.take() {
+            token.cancel();
+        }
+
+        let token = CancellationToken::new();
+        self.cancel_token = Some(token.clone());
+
+        let provider = self.provider.clone_box();
+        let event_tx = self.event_tx.clone();
+        let model = self.config.model.clone();
+        let last_n = self.config.context_messages;
+
+        tokio::spawn(async move {
+            let context = build_context(&req.messages, req.summary.as_deref(), last_n);
+
+            let completion_req = CompletionRequest {
+                model,
+                system: SYSTEM_PROMPT.to_string(),
+                context,
+                partial_input: req.partial_input,
+            };
+
+            match provider.complete(completion_req, token).await {
+                Ok(text) if !text.is_empty() => {
+                    let _ = event_tx.send(AppEvent::AiSuggestion(text));
+                }
+                Err(e) if e.to_string() != "cancelled" => {
+                    let _ = event_tx.send(AppEvent::AiError(e.to_string()));
+                }
+                _ => {}
+            }
+        });
+    }
+}

--- a/src/ai/worker.rs
+++ b/src/ai/worker.rs
@@ -53,11 +53,15 @@ impl AiWorker {
                 partial_input: req.partial_input,
             };
 
+            let check_token = token.clone();
             match provider.complete(completion_req, token).await {
                 Ok(text) if !text.is_empty() => {
                     let _ = event_tx.send(AppEvent::AiSuggestion(text));
                 }
-                Err(e) if e.to_string() != "cancelled" => {
+                Err(_) if check_token.is_cancelled() => {
+                    // Request was cancelled — silently ignore
+                }
+                Err(e) => {
                     let _ = event_tx.send(AppEvent::AiError(e.to_string()));
                 }
                 _ => {}

--- a/src/app.rs
+++ b/src/app.rs
@@ -63,8 +63,11 @@ impl App {
 
         let (db_summary_tx, db_summary_rx) = tokio::sync::mpsc::unbounded_channel::<(String, String)>();
 
+        let mut state = AppState::new();
+        state.ai_debug = config.ai.debug;
+
         Self {
-            state: AppState::new(),
+            state,
             router: MessageRouter::new(),
             db,
             address_book,
@@ -190,6 +193,11 @@ impl App {
                                             .collect();
                                         let summary = self.state.selected_chat_id()
                                             .and_then(|id| self.db.get_preference(&format!("ai_summary:{}", id)).ok().flatten());
+                                        self.state.push_ai_log(format!(
+                                            "[debounce] → POST {}/v1/chat/completions | model={} | ctx={} msgs | input={:?}",
+                                            self.config.ai.base_url, self.config.ai.model, messages.len(),
+                                            if partial.len() > 40 { &partial[..40] } else { &partial }
+                                        ));
                                         worker.request(AiRequest { partial_input: partial, messages, summary });
                                     }
                                 }
@@ -209,11 +217,13 @@ impl App {
                 }
                 Some(AppEvent::AiSuggestion(text)) => {
                     if self.state.input_mode == InputMode::Editing {
+                        self.state.push_ai_log(format!("[suggestion] ← {:?}", text));
                         self.state.ai_suggestion = Some(text);
-                        self.state.ai_status = None;  // clear any previous error
+                        self.state.ai_status = None;
                     }
                 }
                 Some(AppEvent::AiError(e)) => {
+                    self.state.push_ai_log(format!("[error] ← {}", e));
                     self.state.ai_status = Some(format!("AI: {}", e));
                 }
                 Some(AppEvent::Quit) | None => {
@@ -681,6 +691,11 @@ impl App {
                                 .collect();
                             let summary = self.state.selected_chat_id()
                                 .and_then(|id| self.db.get_preference(&format!("ai_summary:{}", id)).ok().flatten());
+                            self.state.push_ai_log(format!(
+                                "[Ctrl+Space] → POST {}/v1/chat/completions | model={} | ctx={} msgs | input={:?}",
+                                self.config.ai.base_url, self.config.ai.model, messages.len(),
+                                if partial.len() > 40 { &partial[..40] } else { &partial }
+                            ));
                             worker.request(AiRequest { partial_input: partial, messages, summary });
                         }
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -198,6 +198,14 @@ impl App {
                                             self.config.ai.base_url, self.config.ai.model, messages.len(),
                                             if partial.len() > 40 { &partial[..40] } else { &partial }
                                         ));
+                                        tracing::info!(
+                                            trigger = "debounce",
+                                            url = %format!("{}/v1/chat/completions", self.config.ai.base_url),
+                                            model = %self.config.ai.model,
+                                            context_msgs = messages.len(),
+                                            input = %partial,
+                                            "AI autocomplete request"
+                                        );
                                         worker.request(AiRequest { partial_input: partial, messages, summary });
                                     }
                                 }
@@ -217,12 +225,14 @@ impl App {
                 }
                 Some(AppEvent::AiSuggestion(text)) => {
                     if self.state.input_mode == InputMode::Editing {
+                        tracing::info!(suggestion = %text, "AI autocomplete suggestion received");
                         self.state.push_ai_log(format!("[suggestion] ← {:?}", text));
                         self.state.ai_suggestion = Some(text);
                         self.state.ai_status = None;
                     }
                 }
                 Some(AppEvent::AiError(e)) => {
+                    tracing::info!(error = %e, "AI autocomplete error");
                     self.state.push_ai_log(format!("[error] ← {}", e));
                     self.state.ai_status = Some(format!("AI: {}", e));
                 }
@@ -696,6 +706,14 @@ impl App {
                                 self.config.ai.base_url, self.config.ai.model, messages.len(),
                                 if partial.len() > 40 { &partial[..40] } else { &partial }
                             ));
+                            tracing::info!(
+                                trigger = "ctrl+space",
+                                url = %format!("{}/v1/chat/completions", self.config.ai.base_url),
+                                model = %self.config.ai.model,
+                                context_msgs = messages.len(),
+                                input = %partial,
+                                "AI autocomplete request"
+                            );
                             worker.request(AiRequest { partial_input: partial, messages, summary });
                         }
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -568,6 +568,7 @@ impl App {
                     self.refresh_title();
                 }
             }
+            Action::AiSuggestAccept | Action::AiSuggestRequest => {}
             Action::None => {}
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -340,20 +340,25 @@ impl App {
                         }
                     }
 
-                    // Move chat to top of list (like WhatsApp)
+                    // Move chat to top of its group (pinned→top of pinned, unpinned→top of unpinned)
                     if let Some(pos) = self.state.chats.iter().position(|c| c.id == msg.chat_id) {
-                        if pos > 0 {
-                            let selected_id = self.state.selected_chat_id().map(|s| s.to_string());
-                            let chat = self.state.chats.remove(pos);
-                            // Insert after the last pinned chat so pinned chats stay at the top
-                            let insert_pos = self.state.chats.iter().rposition(|c| c.is_pinned).map(|p| p + 1).unwrap_or(0);
+                        let selected_id = self.state.selected_chat_id().map(|s| s.to_string());
+                        let chat = self.state.chats.remove(pos);
+                        let insert_pos = if chat.is_pinned {
+                            0
+                        } else {
+                            // Top of unpinned section = one after the last pinned chat
+                            self.state.chats.iter().rposition(|c| c.is_pinned).map(|p| p + 1).unwrap_or(0)
+                        };
+                        if pos != insert_pos {
                             self.state.chats.insert(insert_pos, chat);
-                            // Keep selection on the same chat
                             if let Some(id) = selected_id {
                                 if let Some(new_pos) = self.state.chats.iter().position(|c| c.id == id) {
                                     self.state.chat_list_state.select(Some(new_pos));
                                 }
                             }
+                        } else {
+                            self.state.chats.insert(pos, chat);
                         }
                     }
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,6 +38,8 @@ pub struct App {
     config_path: PathBuf,
     ai_worker: Option<AiWorker>,
     last_keystroke: Option<Instant>,
+    db_summary_tx: tokio::sync::mpsc::UnboundedSender<(String, String)>,
+    db_summary_rx: tokio::sync::mpsc::UnboundedReceiver<(String, String)>,
 }
 
 impl App {
@@ -59,6 +61,8 @@ impl App {
             None
         };
 
+        let (db_summary_tx, db_summary_rx) = tokio::sync::mpsc::unbounded_channel::<(String, String)>();
+
         Self {
             state: AppState::new(),
             router: MessageRouter::new(),
@@ -68,6 +72,8 @@ impl App {
             config_path,
             ai_worker,
             last_keystroke: None,
+            db_summary_tx,
+            db_summary_rx,
         }
     }
 
@@ -160,6 +166,10 @@ impl App {
                 }
                 Some(AppEvent::Tick) => {
                     self.handle_tick();
+                    // Save any pending AI summaries to DB
+                    while let Ok((key, value)) = self.db_summary_rx.try_recv() {
+                        let _ = self.db.set_preference(&key, &value);
+                    }
                     // AI debounce: fire request after user stops typing
                     if let Some(t) = self.last_keystroke {
                         let debounce = Duration::from_millis(self.config.ai.debounce_ms);
@@ -278,6 +288,26 @@ impl App {
                     if is_current_chat {
                         self.state.messages.push(msg.clone());
                         self.state.scroll_offset = 0; // auto-scroll to bottom
+
+                        if let Some(worker) = &self.ai_worker {
+                            if let Some(chat_id) = self.state.selected_chat_id() {
+                                let messages: Vec<crate::ai::context::RawMessage> = self.state.messages.iter()
+                                    .filter_map(|m| {
+                                        let text = match &m.content {
+                                            crate::core::types::MessageContent::Text(t) => t.clone(),
+                                            _ => return None,
+                                        };
+                                        Some(crate::ai::context::RawMessage { is_outgoing: m.is_outgoing, text })
+                                    })
+                                    .collect();
+                                worker.maybe_generate_summary(
+                                    chat_id.to_string(),
+                                    messages,
+                                    self.config.ai.summary_threshold,
+                                    self.db_summary_tx.clone(),
+                                );
+                            }
+                        }
                     }
 
                     // Move chat to top of list (like WhatsApp)

--- a/src/app.rs
+++ b/src/app.rs
@@ -200,6 +200,7 @@ impl App {
                 Some(AppEvent::AiSuggestion(text)) => {
                     if self.state.input_mode == InputMode::Editing {
                         self.state.ai_suggestion = Some(text);
+                        self.state.ai_status = None;  // clear any previous error
                     }
                 }
                 Some(AppEvent::AiError(e)) => {
@@ -410,6 +411,7 @@ impl App {
             Action::ExitEditing => {
                 self.state.exit_editing();
                 self.state.ai_suggestion = None;
+                self.state.ai_status = None;
             }
             Action::SubmitMessage => {
                 let input = self.state.take_input();
@@ -443,7 +445,7 @@ impl App {
             Action::InputKey(key) => {
                 self.state.input.input(key);
                 self.state.ai_suggestion = None;
-                if self.state.input_mode == InputMode::Editing {
+                if self.ai_worker.is_some() && self.state.input_mode == InputMode::Editing {
                     self.last_keystroke = Some(Instant::now());
                 }
             }
@@ -633,6 +635,7 @@ impl App {
                 }
             }
             Action::AiSuggestRequest => {
+                self.last_keystroke = None;
                 if self.state.input_mode == InputMode::Editing {
                     let partial = self.state.input.lines().join("\n");
                     if !partial.is_empty() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use std::io;
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use crossterm::{
     execute,
@@ -7,6 +8,11 @@ use crossterm::{
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
 
+use crate::ai::worker::{AiWorker, AiRequest};
+use crate::ai::context::RawMessage;
+use crate::ai::providers::openai::OpenAiClient;
+use crate::ai::providers::anthropic::AnthropicClient;
+use crate::ai::providers::gemini::GeminiClient;
 use crate::config::AppConfig;
 use crate::core::provider::ProviderEvent;
 use crate::core::types::{AuthStatus, MessageContent, Platform};
@@ -30,10 +36,29 @@ pub struct App {
     address_book: AddressBook,
     config: AppConfig,
     config_path: PathBuf,
+    ai_worker: Option<AiWorker>,
+    last_keystroke: Option<Instant>,
 }
 
 impl App {
-    pub fn new(config: AppConfig, db: Database, address_book: AddressBook, config_path: PathBuf) -> Self {
+    pub fn new(
+        config: AppConfig,
+        db: Database,
+        address_book: AddressBook,
+        config_path: PathBuf,
+        event_tx: tokio::sync::mpsc::UnboundedSender<AppEvent>,
+    ) -> Self {
+        let ai_worker = if config.ai.enabled {
+            let provider: Box<dyn crate::ai::providers::AiProvider> = match config.ai.provider.as_str() {
+                "anthropic" => Box::new(AnthropicClient::new(config.ai.api_key.clone())),
+                "gemini"    => Box::new(GeminiClient::new(config.ai.api_key.clone())),
+                _           => Box::new(OpenAiClient::new(config.ai.base_url.clone(), config.ai.api_key.clone())),
+            };
+            Some(AiWorker::new(provider, config.ai.clone(), event_tx))
+        } else {
+            None
+        };
+
         Self {
             state: AppState::new(),
             router: MessageRouter::new(),
@@ -41,10 +66,12 @@ impl App {
             address_book,
             config,
             config_path,
+            ai_worker,
+            last_keystroke: None,
         }
     }
 
-    pub async fn run(&mut self) -> anyhow::Result<()> {
+    pub async fn run(&mut self, mut events: EventHandler) -> anyhow::Result<()> {
         // Load enter_sends preference from DB (default true)
         self.state.enter_sends = self.db
             .get_preference("enter_sends")
@@ -123,12 +150,6 @@ impl App {
             original_hook(panic_info);
         }));
 
-        // Event handler
-        let mut events = EventHandler::new(
-            self.config.tui.tick_rate_ms,
-            self.config.tui.render_rate_ms,
-        );
-
         // Main loop
         loop {
             let event = events.next().await;
@@ -139,6 +160,32 @@ impl App {
                 }
                 Some(AppEvent::Tick) => {
                     self.handle_tick();
+                    // AI debounce: fire request after user stops typing
+                    if let Some(t) = self.last_keystroke {
+                        let debounce = Duration::from_millis(self.config.ai.debounce_ms);
+                        if t.elapsed() >= debounce {
+                            self.last_keystroke = None;
+                            if self.state.input_mode == InputMode::Editing {
+                                let partial = self.state.input.lines().join("\n");
+                                if !partial.is_empty() {
+                                    if let Some(worker) = self.ai_worker.as_mut() {
+                                        let messages: Vec<RawMessage> = self.state.messages.iter()
+                                            .filter_map(|m| {
+                                                let text = match &m.content {
+                                                    crate::core::types::MessageContent::Text(t) => t.clone(),
+                                                    _ => return None,
+                                                };
+                                                Some(RawMessage { is_outgoing: m.is_outgoing, text })
+                                            })
+                                            .collect();
+                                        let summary = self.state.selected_chat_id()
+                                            .and_then(|id| self.db.get_preference(&format!("ai_summary:{}", id)).ok().flatten());
+                                        worker.request(AiRequest { partial_input: partial, messages, summary });
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
                 Some(AppEvent::Key(key)) => {
                     let action = map_key(key, self.state.input_mode, self.state.enter_sends);
@@ -150,8 +197,13 @@ impl App {
                 Some(AppEvent::Resize(_, _)) => {
                     // Terminal handles resize automatically
                 }
-                Some(AppEvent::AiSuggestion(_)) | Some(AppEvent::AiError(_)) => {
-                    // Handled in Task 7 when AiWorker is wired into app
+                Some(AppEvent::AiSuggestion(text)) => {
+                    if self.state.input_mode == InputMode::Editing {
+                        self.state.ai_suggestion = Some(text);
+                    }
+                }
+                Some(AppEvent::AiError(e)) => {
+                    self.state.ai_status = Some(format!("AI: {}", e));
                 }
                 Some(AppEvent::Quit) | None => {
                     break;
@@ -357,6 +409,7 @@ impl App {
             }
             Action::ExitEditing => {
                 self.state.exit_editing();
+                self.state.ai_suggestion = None;
             }
             Action::SubmitMessage => {
                 let input = self.state.take_input();
@@ -389,6 +442,10 @@ impl App {
             }
             Action::InputKey(key) => {
                 self.state.input.input(key);
+                self.state.ai_suggestion = None;
+                if self.state.input_mode == InputMode::Editing {
+                    self.last_keystroke = Some(Instant::now());
+                }
             }
             Action::ClearInput => {
                 self.state.input = TextArea::default();
@@ -568,7 +625,34 @@ impl App {
                     self.refresh_title();
                 }
             }
-            Action::AiSuggestAccept | Action::AiSuggestRequest => {}
+            Action::AiSuggestAccept => {
+                if let Some(suggestion) = self.state.ai_suggestion.take() {
+                    for ch in suggestion.chars() {
+                        self.state.input.insert_char(ch);
+                    }
+                }
+            }
+            Action::AiSuggestRequest => {
+                if self.state.input_mode == InputMode::Editing {
+                    let partial = self.state.input.lines().join("\n");
+                    if !partial.is_empty() {
+                        if let Some(worker) = self.ai_worker.as_mut() {
+                            let messages: Vec<RawMessage> = self.state.messages.iter()
+                                .filter_map(|m| {
+                                    let text = match &m.content {
+                                        crate::core::types::MessageContent::Text(t) => t.clone(),
+                                        _ => return None,
+                                    };
+                                    Some(RawMessage { is_outgoing: m.is_outgoing, text })
+                                })
+                                .collect();
+                            let summary = self.state.selected_chat_id()
+                                .and_then(|id| self.db.get_preference(&format!("ai_summary:{}", id)).ok().flatten());
+                            worker.request(AiRequest { partial_input: partial, messages, summary });
+                        }
+                    }
+                }
+            }
             Action::None => {}
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -134,11 +134,25 @@ impl App {
                 })
                 .collect();
 
-            // Apply display names from address book
+            // Apply display names from address book (user-set, highest priority)
             if let Ok(names) = self.address_book.get_all_display_names() {
                 for chat in &mut chats {
                     if let Some(name) = names.get(&chat.id) {
                         chat.display_name = Some(name.clone());
+                    }
+                }
+            }
+            // Apply contact names to chats that still show a raw phone number
+            for chat in &mut chats {
+                if chat.display_name.is_some() {
+                    continue;
+                }
+                if let Some(phone) = Self::extract_wa_phone(&chat.id) {
+                    let is_numeric = chat.name.chars().all(|c| c.is_ascii_digit() || c == '+');
+                    if is_numeric {
+                        if let Ok(Some(contact_name)) = self.address_book.lookup_contact(phone) {
+                            chat.name = contact_name;
+                        }
                     }
                 }
             }
@@ -278,6 +292,22 @@ impl App {
                         tracing::error!("Failed to insert message: {}", e);
                     }
 
+                    // Store push_name as contact so we can name phone-number chats
+                    if !msg.is_outgoing && msg.sender != "You" && !msg.sender.is_empty() {
+                        if let Some(phone) = Self::extract_wa_phone(&msg.chat_id) {
+                            let _ = self.address_book.upsert_contact(phone, &msg.sender);
+                            // Apply to the in-memory chat if it still shows a phone number
+                            if let Some(chat) = self.state.chats.iter_mut().find(|c| c.id == msg.chat_id) {
+                                if chat.display_name.is_none() {
+                                    let is_numeric = chat.name.chars().all(|c| c.is_ascii_digit() || c == '+');
+                                    if is_numeric {
+                                        chat.name = msg.sender.clone();
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     // Update last_message on the chat
                     let preview = msg.content.as_text().to_string();
                     let _ = self.db.update_last_message(&msg.chat_id, &preview);
@@ -389,7 +419,16 @@ impl App {
                                 existing.name = chat.name;
                             }
                         } else {
-                            self.state.chats.push(chat);
+                            // Apply address-book / contact name to newly discovered chats
+                            let mut new_chat = chat;
+                            if let Some(name) = self.resolve_contact_name(&new_chat.id) {
+                                new_chat.display_name = Some(name);
+                            } else if let Some(phone) = Self::extract_wa_phone(&new_chat.id) {
+                                if let Ok(Some(contact_name)) = self.address_book.lookup_contact(phone) {
+                                    new_chat.name = contact_name;
+                                }
+                            }
+                            self.state.chats.push(new_chat);
                         }
                     }
                     // Note: no load_selected_chat_messages() here —
@@ -815,5 +854,34 @@ impl App {
     fn update_title(has_unread: bool) {
         let title = if has_unread { "● zero-drift-chat" } else { "zero-drift-chat" };
         let _ = execute!(io::stdout(), SetTitle(title));
+    }
+
+    /// Extract the phone/identifier from a WhatsApp chat_id like `wa-559985213786@s.whatsapp.net`.
+    /// Returns the part before `@`, or None for non-WA or group/newsletter chats.
+    fn extract_wa_phone(chat_id: &str) -> Option<&str> {
+        let raw = chat_id.strip_prefix("wa-")?;
+        // Only direct (non-group, non-newsletter) chats
+        if raw.contains("@g.us") || raw.contains("@newsletter") || raw.contains("@lid") {
+            return None;
+        }
+        Some(raw.split('@').next().unwrap_or(raw))
+    }
+
+    /// Resolve a display name for a chat: address-book display_name first,
+    /// then contacts table by phone, then None.
+    fn resolve_contact_name(&self, chat_id: &str) -> Option<String> {
+        // 1. User-set display name wins
+        if let Ok(names) = self.address_book.get_all_display_names() {
+            if let Some(name) = names.get(chat_id) {
+                return Some(name.clone());
+            }
+        }
+        // 2. Contacts table by phone
+        if let Some(phone) = Self::extract_wa_phone(chat_id) {
+            if let Ok(Some(name)) = self.address_book.lookup_contact(phone) {
+                return Some(name);
+            }
+        }
+        None
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -50,14 +50,24 @@ impl App {
         config_path: PathBuf,
         event_tx: tokio::sync::mpsc::UnboundedSender<AppEvent>,
     ) -> Self {
+        tracing::info!(
+            enabled = config.ai.enabled,
+            provider = %config.ai.provider,
+            base_url = %config.ai.base_url,
+            model = %config.ai.model,
+            debug = config.ai.debug,
+            "AI config loaded"
+        );
         let ai_worker = if config.ai.enabled {
             let provider: Box<dyn crate::ai::providers::AiProvider> = match config.ai.provider.as_str() {
                 "anthropic" => Box::new(AnthropicClient::new(config.ai.api_key.clone())),
                 "gemini"    => Box::new(GeminiClient::new(config.ai.api_key.clone())),
                 _           => Box::new(OpenAiClient::new(config.ai.base_url.clone(), config.ai.api_key.clone())),
             };
+            tracing::info!("AI worker created — autocomplete enabled");
             Some(AiWorker::new(provider, config.ai.clone(), event_tx))
         } else {
+            tracing::info!("AI worker NOT created — ai.enabled = false in config");
             None
         };
 
@@ -605,23 +615,29 @@ impl App {
                     let chat_id = menu.chat_id.clone();
                     let new_pinned = !menu.is_pinned;
 
-                    if let Some(ChatMenuItem::TogglePin) = selected_item {
-                        // Enforce max 10 pinned chats
-                        if new_pinned && self.state.chats.iter().filter(|c| c.is_pinned).count() >= 10 {
-                            self.state.close_chat_menu();
-                            return;
+                    match selected_item {
+                        Some(ChatMenuItem::TogglePin) => {
+                            // Enforce max 10 pinned chats
+                            if new_pinned && self.state.chats.iter().filter(|c| c.is_pinned).count() >= 10 {
+                                self.state.close_chat_menu();
+                                return;
+                            }
+                            let _ = self.db.set_chat_pinned(&chat_id, new_pinned);
+                            if let Some(chat) = self.state.chats.iter_mut().find(|c| c.id == chat_id) {
+                                chat.is_pinned = new_pinned;
+                            }
+                            self.state.chats.sort_by_key(|c| std::cmp::Reverse(c.is_pinned));
+                            let new_idx = self.state.chats.iter().position(|c| c.id == chat_id).unwrap_or(0);
+                            self.state.chat_list_state.select(Some(new_idx));
                         }
-                        // Persist to DB
-                        let _ = self.db.set_chat_pinned(&chat_id, new_pinned);
-                        // Update in-memory chat list
-                        if let Some(chat) = self.state.chats.iter_mut().find(|c| c.id == chat_id) {
-                            chat.is_pinned = new_pinned;
+                        Some(ChatMenuItem::ToggleMute) => {
+                            let new_muted = !menu.is_muted;
+                            let _ = self.db.set_chat_muted(&chat_id, new_muted);
+                            if let Some(chat) = self.state.chats.iter_mut().find(|c| c.id == chat_id) {
+                                chat.is_muted = new_muted;
+                            }
                         }
-                        // Re-sort: pinned chats first, preserve relative order otherwise
-                        self.state.chats.sort_by_key(|c| std::cmp::Reverse(c.is_pinned));
-                        // Select the chat that was just pinned/unpinned at its new position
-                        let new_idx = self.state.chats.iter().position(|c| c.id == chat_id).unwrap_or(0);
-                        self.state.chat_list_state.select(Some(new_idx));
+                        None => {}
                     }
                 }
                 self.state.close_chat_menu();

--- a/src/app.rs
+++ b/src/app.rs
@@ -150,6 +150,9 @@ impl App {
                 Some(AppEvent::Resize(_, _)) => {
                     // Terminal handles resize automatically
                 }
+                Some(AppEvent::AiSuggestion(_)) | Some(AppEvent::AiError(_)) => {
+                    // Handled in Task 7 when AiWorker is wired into app
+                }
                 Some(AppEvent::Quit) | None => {
                     break;
                 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -96,12 +96,24 @@ fn default_message_interval() -> u64 {
     3
 }
 
-fn default_ai_provider() -> String { "ollama".to_string() }
-fn default_ai_base_url() -> String { "http://localhost:11434".to_string() }
-fn default_ai_model() -> String { "qwen2.5:1.5b-instruct".to_string() }
-fn default_context_messages() -> usize { 10 }
-fn default_summary_threshold() -> usize { 50 }
-fn default_debounce_ms() -> u64 { 500 }
+fn default_ai_provider() -> String {
+    "ollama".to_string()
+}
+fn default_ai_base_url() -> String {
+    "http://localhost:11434".to_string()
+}
+fn default_ai_model() -> String {
+    "qwen2.5:1.5b-instruct".to_string()
+}
+fn default_context_messages() -> usize {
+    10
+}
+fn default_summary_threshold() -> usize {
+    50
+}
+fn default_debounce_ms() -> u64 {
+    500
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AiConfig {
@@ -111,8 +123,7 @@ pub struct AiConfig {
     pub provider: String,
     #[serde(default = "default_ai_base_url")]
     pub base_url: String,
-    #[serde(default)]
-    pub api_key: String,
+    pub api_key: Option<String>,
     #[serde(default = "default_ai_model")]
     pub model: String,
     #[serde(default = "default_context_messages")]
@@ -129,7 +140,7 @@ impl Default for AiConfig {
             enabled: false,
             provider: default_ai_provider(),
             base_url: default_ai_base_url(),
-            api_key: String::new(),
+            api_key: None,
             model: default_ai_model(),
             context_messages: default_context_messages(),
             summary_threshold: default_summary_threshold(),

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -13,6 +13,8 @@ pub struct AppConfig {
     pub mock_provider: MockProviderConfig,
     #[serde(default)]
     pub whatsapp: WhatsAppConfig,
+    #[serde(default)]
+    pub ai: AiConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -94,6 +96,48 @@ fn default_message_interval() -> u64 {
     3
 }
 
+fn default_ai_provider() -> String { "ollama".to_string() }
+fn default_ai_base_url() -> String { "http://localhost:11434".to_string() }
+fn default_ai_model() -> String { "qwen2.5:1.5b-instruct".to_string() }
+fn default_context_messages() -> usize { 10 }
+fn default_summary_threshold() -> usize { 50 }
+fn default_debounce_ms() -> u64 { 500 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_ai_provider")]
+    pub provider: String,
+    #[serde(default = "default_ai_base_url")]
+    pub base_url: String,
+    #[serde(default)]
+    pub api_key: String,
+    #[serde(default = "default_ai_model")]
+    pub model: String,
+    #[serde(default = "default_context_messages")]
+    pub context_messages: usize,
+    #[serde(default = "default_summary_threshold")]
+    pub summary_threshold: usize,
+    #[serde(default = "default_debounce_ms")]
+    pub debounce_ms: u64,
+}
+
+impl Default for AiConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            provider: default_ai_provider(),
+            base_url: default_ai_base_url(),
+            api_key: String::new(),
+            model: default_ai_model(),
+            context_messages: default_context_messages(),
+            summary_threshold: default_summary_threshold(),
+            debounce_ms: default_debounce_ms(),
+        }
+    }
+}
+
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
@@ -101,6 +145,7 @@ impl Default for AppConfig {
             tui: TuiConfig::default(),
             mock_provider: MockProviderConfig::default(),
             whatsapp: WhatsAppConfig::default(),
+            ai: AiConfig::default(),
         }
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -123,6 +123,7 @@ pub struct AiConfig {
     pub provider: String,
     #[serde(default = "default_ai_base_url")]
     pub base_url: String,
+    #[serde(default)]
     pub api_key: Option<String>,
     #[serde(default = "default_ai_model")]
     pub model: String,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -198,7 +198,8 @@ impl AppConfig {
     pub fn load(path: &Path) -> Result<Self> {
         if path.exists() {
             let content = std::fs::read_to_string(path)?;
-            let config: AppConfig = toml::from_str(&content)?;
+            let config: AppConfig = toml::from_str(&content)
+                .map_err(|e| anyhow::anyhow!("Failed to parse config {}: {}", path.display(), e))?;
             Ok(config)
         } else {
             Ok(Self::default())
@@ -217,5 +218,32 @@ impl AppConfig {
         );
         std::fs::write(path, content)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_ai_config() {
+        let toml = r#"
+[ai]
+enabled = true
+provider = "ollama"
+base_url = "http://localhost:8080"
+model = "qwen2.5-1.5b-instruct-q4_k_m"
+context_messages = 10
+summary_threshold = 50
+debounce_ms = 500
+debug = true
+"#;
+        let result = toml::from_str::<AppConfig>(toml);
+        assert!(result.is_ok(), "parse failed: {:?}", result.err());
+        let cfg = result.unwrap();
+        assert!(cfg.ai.enabled, "ai.enabled should be true");
+        assert_eq!(cfg.ai.base_url, "http://localhost:8080");
+        assert_eq!(cfg.ai.model, "qwen2.5-1.5b-instruct-q4_k_m");
+        assert!(cfg.ai.debug);
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -132,6 +132,8 @@ pub struct AiConfig {
     pub summary_threshold: usize,
     #[serde(default = "default_debounce_ms")]
     pub debounce_ms: u64,
+    #[serde(default)]
+    pub debug: bool,
 }
 
 impl Default for AiConfig {
@@ -145,6 +147,7 @@ impl Default for AiConfig {
             context_messages: default_context_messages(),
             summary_threshold: default_summary_threshold(),
             debounce_ms: default_debounce_ms(),
+            debug: false,
         }
     }
 }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -89,4 +89,5 @@ pub struct UnifiedChat {
     pub is_group: bool,
     pub is_pinned: bool,
     pub is_newsletter: bool,
+    pub is_muted: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,9 +36,18 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     // Load config
-    let config_path = cli
-        .config
-        .unwrap_or_else(|| PathBuf::from("configs/default.toml"));
+    let config_path = cli.config.unwrap_or_else(|| {
+        // Prefer repo-local config if running from the repo, otherwise use user config dir
+        let local = PathBuf::from("configs/default.toml");
+        if local.exists() {
+            local
+        } else {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(".zero-drift-chat")
+                .join("config.toml")
+        }
+    });
     let config = AppConfig::load(&config_path)?;
 
     // Set up data directory

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod core;
 mod providers;
 mod storage;
 mod tui;
+mod ai;
 
 use std::path::PathBuf;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use clap::Parser;
 use crate::app::App;
 use crate::config::AppConfig;
 use crate::storage::{AddressBook, Database};
+use crate::tui::event::EventHandler;
 
 #[derive(Parser, Debug)]
 #[command(name = "zero-drift-chat", about = "Unified messaging TUI")]
@@ -109,8 +110,9 @@ async fn main() -> anyhow::Result<()> {
     let address_book = AddressBook::open(ab_path.to_str().unwrap_or("addressbook.db"))?;
 
     // Run app
-    let mut app = App::new(config, db, address_book, config_path);
-    app.run().await?;
+    let event_handler = EventHandler::new(config.tui.tick_rate_ms, config.tui.render_rate_ms);
+    let mut app = App::new(config, db, address_book, config_path, event_handler.sender());
+    app.run(event_handler).await?;
 
     tracing::info!("zero-drift-chat exited cleanly");
     Ok(())

--- a/src/providers/mock/mod.rs
+++ b/src/providers/mock/mod.rs
@@ -83,6 +83,7 @@ impl MockProvider {
                 is_group: i == 2, // "Team Standup"
                 is_pinned: false,
                 is_newsletter: NEWSLETTER_INDICES.contains(&i),
+                is_muted: false,
             })
             .collect()
     }

--- a/src/providers/whatsapp/mod.rs
+++ b/src/providers/whatsapp/mod.rs
@@ -271,6 +271,7 @@ fn handle_wa_event(
                     is_group: source.is_group,
                     is_pinned: false,
                     is_newsletter,
+                    is_muted: false,
                 };
 
                 let _ = tx.send(ProviderEvent::ChatsUpdated(vec![chat]));
@@ -350,6 +351,7 @@ fn handle_wa_event(
                         is_group,
                         is_pinned: false,
                         is_newsletter,
+                        is_muted: false,
                     };
 
                     let _ = tx.send(ProviderEvent::ChatsUpdated(vec![chat]));

--- a/src/storage/addressbook.rs
+++ b/src/storage/addressbook.rs
@@ -21,11 +21,16 @@ impl AddressBook {
             "CREATE TABLE IF NOT EXISTS display_names (
                 chat_id TEXT PRIMARY KEY,
                 display_name TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS contacts (
+                phone TEXT PRIMARY KEY,
+                name TEXT NOT NULL
             );",
         )?;
         Ok(())
     }
 
+    /// User-set display names, keyed by chat_id. Highest priority.
     pub fn get_all_display_names(&self) -> Result<HashMap<String, String>> {
         let mut stmt = self
             .conn
@@ -48,5 +53,39 @@ impl AddressBook {
             rusqlite::params![chat_id, display_name],
         )?;
         Ok(())
+    }
+
+    /// Store a contact name from push_name / contact sync.
+    /// Does NOT overwrite if the name is already set (user-synced names take priority).
+    pub fn upsert_contact(&self, phone: &str, name: &str) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO contacts (phone, name) VALUES (?1, ?2)
+             ON CONFLICT(phone) DO UPDATE SET name = excluded.name",
+            rusqlite::params![phone, name],
+        )?;
+        Ok(())
+    }
+
+    /// Look up a contact name by phone number (partial match: `phone` should be
+    /// the normalized number without country-code prefix inconsistencies).
+    pub fn lookup_contact(&self, phone: &str) -> Result<Option<String>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT name FROM contacts WHERE phone = ?1 LIMIT 1")?;
+        let mut rows = stmt.query(rusqlite::params![phone])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(row.get(0)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// All contacts, for search/display. Returns (phone, name).
+    pub fn get_all_contacts(&self) -> Result<Vec<(String, String)>> {
+        let mut stmt = self.conn.prepare("SELECT phone, name FROM contacts ORDER BY name")?;
+        let rows = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
     }
 }

--- a/src/storage/chats.rs
+++ b/src/storage/chats.rs
@@ -33,7 +33,7 @@ impl Database {
 
     pub fn get_all_chats(&self) -> Result<Vec<UnifiedChat>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, platform, name, last_message, unread_count, is_group, display_name, pinned, is_newsletter
+            "SELECT id, platform, name, last_message, unread_count, is_group, display_name, pinned, is_newsletter, muted
              FROM chats ORDER BY pinned DESC, updated_at DESC",
         )?;
 
@@ -48,14 +48,15 @@ impl Database {
                 let display_name: Option<String> = row.get(6)?;
                 let pinned: i32 = row.get(7)?;
                 let is_newsletter: i32 = row.get(8)?;
+                let muted: i32 = row.get(9)?;
 
-                Ok((id, platform_str, name, last_message, unread_count, is_group, display_name, pinned, is_newsletter))
+                Ok((id, platform_str, name, last_message, unread_count, is_group, display_name, pinned, is_newsletter, muted))
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
         let result = chats
             .into_iter()
-            .map(|(id, platform_str, name, last_message, unread_count, is_group, display_name, pinned, is_newsletter)| {
+            .map(|(id, platform_str, name, last_message, unread_count, is_group, display_name, pinned, is_newsletter, muted)| {
                 let platform = match platform_str.as_str() {
                     "WhatsApp" => Platform::WhatsApp,
                     "Telegram" => Platform::Telegram,
@@ -72,11 +73,20 @@ impl Database {
                     is_group: is_group != 0,
                     is_pinned: pinned != 0,
                     is_newsletter: is_newsletter != 0,
+                    is_muted: muted != 0,
                 }
             })
             .collect();
 
         Ok(result)
+    }
+
+    pub fn set_chat_muted(&self, chat_id: &str, muted: bool) -> Result<()> {
+        self.conn.execute(
+            "UPDATE chats SET muted = ?1 WHERE id = ?2",
+            rusqlite::params![muted as i32, chat_id],
+        )?;
+        Ok(())
     }
 
     pub fn set_chat_pinned(&self, chat_id: &str, pinned: bool) -> Result<()> {

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -91,6 +91,11 @@ impl Database {
             [],
         );
 
+        // Migration: add muted column if not exists
+        let _ = self
+            .conn
+            .execute("ALTER TABLE chats ADD COLUMN muted INTEGER NOT NULL DEFAULT 0", []);
+
         Ok(())
     }
 }

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -133,13 +133,17 @@ impl SettingsState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChatMenuItem {
     TogglePin,
+    ToggleMute,
 }
 
 impl ChatMenuItem {
-    pub fn label(&self, is_pinned: bool) -> &'static str {
+    pub fn label(&self, is_pinned: bool, is_muted: bool) -> &'static str {
         match self {
             ChatMenuItem::TogglePin => {
                 if is_pinned { "Unpin" } else { "Pin" }
+            }
+            ChatMenuItem::ToggleMute => {
+                if is_muted { "Unmute" } else { "Mute" }
             }
         }
     }
@@ -149,18 +153,20 @@ pub struct ChatMenuState {
     pub chat_id: String,
     pub chat_name: String,
     pub is_pinned: bool,
+    pub is_muted: bool,
     pub selected: usize,
     pub items: Vec<ChatMenuItem>,
 }
 
 impl ChatMenuState {
-    pub fn new(chat_id: String, chat_name: String, is_pinned: bool) -> Self {
+    pub fn new(chat_id: String, chat_name: String, is_pinned: bool, is_muted: bool) -> Self {
         Self {
             chat_id,
             chat_name,
             is_pinned,
+            is_muted,
             selected: 0,
-            items: vec![ChatMenuItem::TogglePin],
+            items: vec![ChatMenuItem::TogglePin, ChatMenuItem::ToggleMute],
         }
     }
 
@@ -339,6 +345,7 @@ impl AppState {
                     chat.id.clone(),
                     chat.display_name.clone().unwrap_or_else(|| chat.name.clone()),
                     chat.is_pinned,
+                    chat.is_muted,
                 ));
                 self.input_mode = InputMode::ChatMenu;
             }
@@ -360,6 +367,6 @@ impl AppState {
     }
 
     pub fn has_unread(&self) -> bool {
-        self.chats.iter().any(|c| c.unread_count > 0)
+        self.chats.iter().any(|c| !c.is_muted && c.unread_count > 0)
     }
 }

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -211,6 +211,8 @@ pub struct AppState {
     pub settings_state: Option<SettingsState>,
     pub chat_menu_state: Option<ChatMenuState>,
     pub search_state: Option<SearchState>,
+    pub ai_suggestion: Option<String>,
+    pub ai_status: Option<String>,
     pub enter_sends: bool,
     /// Number of unread messages at the tail of `messages` when a chat was opened.
     pub new_message_count: usize,
@@ -236,6 +238,8 @@ impl AppState {
             settings_state: None,
             chat_menu_state: None,
             search_state: None,
+            ai_suggestion: None,
+            ai_status: None,
             enter_sends: true,
             new_message_count: 0,
         }

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -213,6 +213,8 @@ pub struct AppState {
     pub search_state: Option<SearchState>,
     pub ai_suggestion: Option<String>,
     pub ai_status: Option<String>,
+    pub ai_debug: bool,
+    pub ai_debug_log: Vec<String>,
     pub enter_sends: bool,
     /// Number of unread messages at the tail of `messages` when a chat was opened.
     pub new_message_count: usize,
@@ -240,6 +242,8 @@ impl AppState {
             search_state: None,
             ai_suggestion: None,
             ai_status: None,
+            ai_debug: false,
+            ai_debug_log: Vec::new(),
             enter_sends: true,
             new_message_count: 0,
         }
@@ -344,6 +348,15 @@ impl AppState {
     pub fn close_chat_menu(&mut self) {
         self.chat_menu_state = None;
         self.input_mode = InputMode::Normal;
+    }
+
+    pub fn push_ai_log(&mut self, entry: String) {
+        if self.ai_debug {
+            self.ai_debug_log.push(entry);
+            if self.ai_debug_log.len() > 6 {
+                self.ai_debug_log.remove(0);
+            }
+        }
     }
 
     pub fn has_unread(&self) -> bool {

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -11,16 +11,20 @@ pub enum AppEvent {
     Tick,
     Render,
     Quit,
+    AiSuggestion(String),
+    AiError(String),
 }
 
 pub struct EventHandler {
     rx: mpsc::UnboundedReceiver<AppEvent>,
+    pub tx: mpsc::UnboundedSender<AppEvent>,
     _task: tokio::task::JoinHandle<()>,
 }
 
 impl EventHandler {
     pub fn new(tick_rate_ms: u64, render_rate_ms: u64) -> Self {
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::unbounded_channel::<AppEvent>();
+        let task_tx = tx.clone();
 
         let task = tokio::spawn(async move {
             let mut reader = EventStream::new();
@@ -32,12 +36,12 @@ impl EventHandler {
             loop {
                 tokio::select! {
                     _ = tick_interval.tick() => {
-                        if tx.send(AppEvent::Tick).is_err() {
+                        if task_tx.send(AppEvent::Tick).is_err() {
                             break;
                         }
                     }
                     _ = render_interval.tick() => {
-                        if tx.send(AppEvent::Render).is_err() {
+                        if task_tx.send(AppEvent::Render).is_err() {
                             break;
                         }
                     }
@@ -46,13 +50,13 @@ impl EventHandler {
                             Event::Key(key) => {
                                 // Windows fix: only handle Press events to avoid duplicates
                                 if key.kind == KeyEventKind::Press {
-                                    if tx.send(AppEvent::Key(key)).is_err() {
+                                    if task_tx.send(AppEvent::Key(key)).is_err() {
                                         break;
                                     }
                                 }
                             }
                             Event::Resize(w, h) => {
-                                if tx.send(AppEvent::Resize(w, h)).is_err() {
+                                if task_tx.send(AppEvent::Resize(w, h)).is_err() {
                                     break;
                                 }
                             }
@@ -63,10 +67,14 @@ impl EventHandler {
             }
         });
 
-        Self { rx, _task: task }
+        Self { rx, tx, _task: task }
     }
 
     pub async fn next(&mut self) -> Option<AppEvent> {
         self.rx.recv().await
+    }
+
+    pub fn sender(&self) -> mpsc::UnboundedSender<AppEvent> {
+        self.tx.clone()
     }
 }

--- a/src/tui/keybindings.rs
+++ b/src/tui/keybindings.rs
@@ -125,8 +125,8 @@ fn map_search_mode(key: KeyEvent) -> Action {
     match key.code {
         KeyCode::Esc => Action::SearchClose,
         KeyCode::Enter => Action::SearchConfirm,
-        KeyCode::Char('j') | KeyCode::Down => Action::SearchNext,
-        KeyCode::Char('k') | KeyCode::Up => Action::SearchPrev,
+        KeyCode::Down => Action::SearchNext,
+        KeyCode::Up => Action::SearchPrev,
         _ => Action::SearchInput(key),
     }
 }

--- a/src/tui/keybindings.rs
+++ b/src/tui/keybindings.rs
@@ -35,6 +35,8 @@ pub enum Action {
     SearchPrev,
     SearchConfirm,
     SearchClose,
+    AiSuggestAccept,   // Tab — accept ghost text suggestion
+    AiSuggestRequest,  // Ctrl+Space — on-demand trigger
     None,
 }
 
@@ -91,6 +93,8 @@ fn map_editing_mode(key: KeyEvent, enter_sends: bool) -> Action {
         (KeyCode::Char('s'), m) if m.contains(KeyModifiers::CONTROL) => Action::SubmitMessage,
         // Ctrl+U always clears
         (KeyCode::Char('u'), m) if m.contains(KeyModifiers::CONTROL) => Action::ClearInput,
+        (KeyCode::Tab, _) => Action::AiSuggestAccept,
+        (KeyCode::Char(' '), m) if m.contains(KeyModifiers::CONTROL) => Action::AiSuggestRequest,
         // Everything else forwarded to TextArea
         _ => Action::InputKey(key),
     }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,5 +1,8 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
     Frame,
 };
 
@@ -25,13 +28,19 @@ pub fn draw(f: &mut Frame, state: &mut AppState) {
 
     // Input box grows with content: +2 for borders, clamped between 3 (1 line) and 8 (6 lines)
     let input_height = (state.input.lines().len() as u16 + 2).clamp(3, 8);
+    let debug_height: u16 = if state.ai_debug { 8 } else { 0 };
     let message_layout = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(input_height)])
+        .constraints([
+            Constraint::Min(1),
+            Constraint::Length(input_height),
+            Constraint::Length(debug_height),
+        ])
         .split(message_area);
 
     let message_view_area = message_layout[0];
     let input_area = message_layout[1];
+    let debug_area = message_layout[2];
 
     // Get current chat name
     let chat_name = state
@@ -67,6 +76,33 @@ pub fn draw(f: &mut Frame, state: &mut AppState) {
         state.input_mode,
         state.ai_suggestion.as_deref(),
     );
+
+    // AI debug panel
+    if state.ai_debug {
+        let log_lines: Vec<Line> = if state.ai_debug_log.is_empty() {
+            vec![Line::from(Span::styled(
+                "  waiting for AI activity... (type something in INSERT mode)",
+                Style::default().fg(Color::DarkGray),
+            ))]
+        } else {
+            state.ai_debug_log.iter().map(|entry| {
+                let color = if entry.starts_with("[error]") {
+                    Color::Red
+                } else if entry.starts_with("[suggestion]") {
+                    Color::Green
+                } else {
+                    Color::Cyan
+                };
+                Line::from(Span::styled(entry.as_str(), Style::default().fg(color)))
+            }).collect()
+        };
+        let debug_widget = Paragraph::new(log_lines)
+            .block(Block::default()
+                .title(" AI Debug ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::DarkGray)));
+        f.render_widget(debug_widget, debug_area);
+    }
 
     status_bar::render_status_bar(
         f,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -65,6 +65,7 @@ pub fn draw(f: &mut Frame, state: &mut AppState) {
         input_area,
         &state.input,
         state.input_mode,
+        state.ai_suggestion.as_deref(),
     );
 
     status_bar::render_status_bar(

--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -116,6 +116,7 @@ mod tests {
             is_group: false,
             is_pinned: false,
             is_newsletter: false,
+            is_muted: false,
         }
     }
 }

--- a/src/tui/widgets/chat_list.rs
+++ b/src/tui/widgets/chat_list.rs
@@ -17,9 +17,16 @@ fn make_item(chat: &UnifiedChat, is_selected: bool) -> ListItem<'static> {
         String::new()
     };
     let name = chat.display_name.as_deref().unwrap_or(&chat.name).to_string();
-    // Embed selector so column layout is always consistent regardless of which list is active
     let selector = if is_selected { "▶ " } else { "  " };
     let pin_tag = if chat.is_pinned { "* " } else { "  " };
+
+    // Muted chats render dimmed
+    let (name_color, unread_color) = if chat.is_muted {
+        (Color::DarkGray, Color::Gray)
+    } else {
+        (Color::White, Color::Yellow)
+    };
+
     let mut spans = vec![
         Span::raw(selector),
         Span::styled(pin_tag.to_string(), Style::default().fg(Color::Yellow)),
@@ -30,8 +37,8 @@ fn make_item(chat: &UnifiedChat, is_selected: bool) -> ListItem<'static> {
         spans.push(Span::styled(tag, Style::default().fg(Color::DarkGray)));
     }
     spans.push(Span::raw(" "));
-    spans.push(Span::styled(name, Style::default().fg(Color::White)));
-    spans.push(Span::styled(unread, Style::default().fg(Color::Yellow)));
+    spans.push(Span::styled(name, Style::default().fg(name_color)));
+    spans.push(Span::styled(unread, Style::default().fg(unread_color)));
     ListItem::new(Line::from(spans))
 }
 
@@ -59,7 +66,7 @@ pub fn render_chat_list(
     } else {
         let total_unread: u32 = chats
             .iter()
-            .filter(|c| !c.is_newsletter)
+            .filter(|c| !c.is_newsletter && !c.is_muted)
             .map(|c| c.unread_count)
             .sum();
         let t = if total_unread > 0 {

--- a/src/tui/widgets/chat_menu.rs
+++ b/src/tui/widgets/chat_menu.rs
@@ -25,7 +25,7 @@ pub fn render_chat_menu(f: &mut Frame, parent_area: Rect, state: &ChatMenuState)
         .map(|item| {
             ListItem::new(Line::from(Span::raw(format!(
                 " {}",
-                item.label(state.is_pinned)
+                item.label(state.is_pinned, state.is_muted)
             ))))
         })
         .collect();

--- a/src/tui/widgets/input_bar.rs
+++ b/src/tui/widgets/input_bar.rs
@@ -13,6 +13,7 @@ pub fn render_input_bar(
     area: Rect,
     textarea: &TextArea<'static>,
     mode: InputMode,
+    ai_suggestion: Option<&str>,
 ) {
     let (mode_tag, border_color, title_align) = match mode {
         InputMode::Normal   => ("NORMAL",   Color::DarkGray, Alignment::Left),
@@ -35,6 +36,26 @@ pub fn render_input_bar(
     if mode == InputMode::Editing || mode == InputMode::Renaming {
         // TextArea widget: handles cursor, horizontal scroll, multi-line display automatically
         f.render_widget(textarea, inner_area);
+
+        // Render AI suggestion hint if present and in editing mode
+        if mode == InputMode::Editing {
+            if let Some(suggestion) = ai_suggestion {
+                if inner_area.height >= 2 {
+                    let hint_area = Rect {
+                        x: inner_area.x,
+                        y: inner_area.y + inner_area.height.saturating_sub(1),
+                        width: inner_area.width,
+                        height: 1,
+                    };
+                    let hint_text = format!("  ↳ {}", suggestion);
+                    f.render_widget(
+                        Paragraph::new(hint_text)
+                            .style(Style::default().fg(Color::DarkGray)),
+                        hint_area,
+                    );
+                }
+            }
+        }
     } else {
         // Normal/Settings: render text only, no hardware cursor in the input box
         let text = textarea.lines().join("\n");


### PR DESCRIPTION
## Release Notes

- **AI autocomplete** — ghost-text suggestions while typing, powered by local (Ollama/llama.cpp) or cloud models (OpenAI/Anthropic/Gemini); debounced + cancellable
- **AI debug panel** — shows live request/response/error events when `ai.debug = true` in config
- **AI context** — hybrid context: per-chat summary + last N raw messages; background summary generation
- **Autocomplete style fix** — suggestions complete in the sender's own voice/style, not as a chatbot reply
- **Mute chat** — chat menu (`x`) → Mute/Unmute; muted chats render dimmed, excluded from header unread count and terminal title dot
- **Contact sync** — push_name auto-stored on message receive; phone-number chats renamed to contact name; persists across restarts
- **Keep renamed** — user display names (via `r`) and synced contact names survive chat list refreshes
- **Search fix** — `j`/`k` now type normally in the find-chat overlay; use ↑/↓ to navigate results
- **Chat jump fix** — new messages move a chat to top of its own group (pinned → top of pinned, unpinned → top of unpinned)
- **Config fix** — `api_key: Option<String>` missing `#[serde(default)]` caused silent fallback to defaults; fixed with explicit parse error reporting

## Test Plan
- [ ] Type in INSERT mode with a local model running — ghost text appears below input
- [ ] Press Tab to accept suggestion, Ctrl+Space to force-trigger
- [ ] Mute a chat via `x` menu — name dims, unread badge excluded from header
- [ ] Rename a chat; restart app — name persists
- [ ] Search (`/`) and type `jk` — letters appear in search box
- [ ] Receive message on a pinned chat — it moves to top of pinned section, not unpinned