### PR TITLE
fix: sync read status from other WhatsApp devices

### DIFF
--- a/src/providers/whatsapp/mod.rs
+++ b/src/providers/whatsapp/mod.rs
@@ -366,6 +366,13 @@ fn handle_wa_event(
                 }
             }
         }
+        Event::MarkChatAsReadUpdate(update) => {
+            if update.action.read == Some(true) {
+                let chat_id = jid_to_chat_id(&update.jid, jid_cache);
+                tracing::debug!("MarkChatAsRead sync from other device: {}", chat_id);
+                let _ = tx.send(ProviderEvent::SelfRead { chat_id });
+            }
+        }
         Event::OfflineSyncCompleted(_) => {
             tracing::info!("WhatsApp offline sync completed");
             let _ = tx.send(ProviderEvent::SyncCompleted);


### PR DESCRIPTION
## Summary

- Closes #12
- When a chat is marked as read on a phone or another linked WhatsApp device, WhatsApp pushes an AppState sync event (`MarkChatAsReadUpdate`) to all linked devices — this is **separate** from the `Receipt(ReadSelf)` path which handles per-message read receipts
- `MarkChatAsReadUpdate` was falling through to the `_ =>` catch-all in `handle_wa_event` and being silently ignored
- Added a handler that emits `ProviderEvent::SelfRead { chat_id }` when `action.read == Some(true)`, which clears the unread count and persists it to the DB

## Root cause

`Event::MarkChatAsReadUpdate` (from `whatsapp-rust`) carries a `MarkChatAsReadAction { read: Option<bool>, ... }`. When you mark a chat as read on your phone, WhatsApp syncs this action to all linked devices. Zero-drift-chat had no handler for it.

## Test plan
- [ ] Mark an unread chat as read on your phone
- [ ] Confirm the chat's unread count clears in zero-drift-chat without restarting

🤖 Generated with [Claude Code](https://claude.com/claude-code)