### PR TITLE
fix: bracketed paste + right-align outgoing messages + [GP] group indicator

### DIFF
--- a/docs/superpowers/plans/2026-03-10-message-layout-group-indicator.md
+++ b/docs/superpowers/plans/2026-03-10-message-layout-group-indicator.md
@@ -1,0 +1,243 @@
+# Message Layout + Group Chat Indicator Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Right-align outgoing messages in the message view, and show a `[GP]` (magenta) indicator for group chats in the chat list.
+
+**Architecture:** Two independent rendering changes in two widget files. Task 1 adds an `else if chat.is_group` branch in `chat_list.rs`. Task 2 adds `Alignment::Right` to outgoing message `Line`s in `message_view.rs` and reverses the header order (time before sender) so right-aligned headers read naturally.
+
+**Tech Stack:** Rust, ratatui 0.29
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/tui/widgets/chat_list.rs` | Add `[GP]` in Magenta when `chat.is_group`, between the `[NL]` and platform-tag branches |
+| `src/tui/widgets/message_view.rs` | Import `Alignment`; apply `.alignment(Alignment::Right)` to outgoing header + content lines; reverse header span order for outgoing |
+
+---
+
+## Chunk 1: Group chat indicator
+
+### Task 1: Show `[GP]` in Magenta for group chats in the chat list
+
+**Files:**
+- Modify: `src/tui/widgets/chat_list.rs:34-38`
+
+The current tag logic (lines 34-38):
+
+```rust
+    if chat.is_newsletter {
+        spans.push(Span::styled("[NL]", Style::default().fg(Color::Cyan)));
+    } else {
+        spans.push(Span::styled(tag, Style::default().fg(Color::DarkGray)));
+    }
+```
+
+- [ ] **Step 1: Add `[GP]` branch**
+
+Change the tag block to:
+
+```rust
+    if chat.is_newsletter {
+        spans.push(Span::styled("[NL]", Style::default().fg(Color::Cyan)));
+    } else if chat.is_group {
+        spans.push(Span::styled("[GP]", Style::default().fg(Color::Magenta)));
+    } else {
+        spans.push(Span::styled(tag, Style::default().fg(Color::DarkGray)));
+    }
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat && cargo test 2>&1
+```
+
+Expected: `test result: ok. 22 passed`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/widgets/chat_list.rs
+git commit -m "feat: show [GP] in magenta for group chats in chat list"
+```
+
+---
+
+## Chunk 2: Right-aligned outgoing messages
+
+### Task 2: Right-align outgoing message header and content in the message view
+
+**Files:**
+- Modify: `src/tui/widgets/message_view.rs:1-8` (imports)
+- Modify: `src/tui/widgets/message_view.rs:126-159` (message rendering loop body)
+
+#### Background
+
+ratatui 0.29 `Line` supports `.alignment(Alignment::Right)`. When applied to a `Line`, ratatui right-justifies it within the available width. This is the correct API — no manual space-padding needed.
+
+For outgoing messages the header order is reversed from `"sender  time"` to `"time  sender"` so it reads naturally when pushed to the right edge.
+
+#### Step-by-step
+
+- [ ] **Step 4: Add `Alignment` to imports**
+
+The current import block (lines 1-8):
+
+```rust
+use chrono::Local;
+use ratatui::{
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+    Frame,
+};
+```
+
+Change to:
+
+```rust
+use chrono::Local;
+use ratatui::{
+    layout::{Alignment, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+    Frame,
+};
+```
+
+- [ ] **Step 5: Right-align outgoing header**
+
+The current header block (lines 126-134):
+
+```rust
+        let header = Line::from(vec![
+            Span::styled(
+                format!("{} ", msg.sender),
+                Style::default().fg(sender_color),
+            ),
+            Span::styled(time, Style::default().fg(Color::DarkGray)),
+        ]);
+
+        lines.push(header);
+```
+
+Change to:
+
+```rust
+        let header = if msg.is_outgoing {
+            // Right-aligned: "10:02  You" pushed to the right edge
+            Line::from(vec![
+                Span::styled(time, Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!("  {}", msg.sender),
+                    Style::default().fg(sender_color),
+                ),
+            ])
+            .alignment(Alignment::Right)
+        } else {
+            // Left-aligned: "You 10:02" (unchanged)
+            Line::from(vec![
+                Span::styled(
+                    format!("{} ", msg.sender),
+                    Style::default().fg(sender_color),
+                ),
+                Span::styled(time, Style::default().fg(Color::DarkGray)),
+            ])
+        };
+
+        lines.push(header);
+```
+
+- [ ] **Step 6: Right-align outgoing content lines**
+
+The current content rendering (lines 139-160, through the closing `}` of the `for` loop body):
+
+```rust
+        for text_line in msg.content.as_text().split('\n') {
+            if !text_line.contains("http://") && !text_line.contains("https://") {
+                // Fast path: no URL prefix — single span, no allocation
+                lines.push(Line::from(Span::styled(
+                    text_line.to_string(),
+                    Style::default().fg(msg_color),
+                )));
+                continue;
+            }
+            let spans: Vec<Span> = split_line_with_urls(text_line)
+                .into_iter()
+                .map(|(seg, is_url)| {
+                    if is_url {
+                        Span::styled(seg.to_string(), url_style)
+                    } else {
+                        Span::styled(seg.to_string(), Style::default().fg(msg_color))
+                    }
+                })
+                .collect();
+            lines.push(Line::from(spans));
+        }
+```
+
+Change to:
+
+```rust
+        for text_line in msg.content.as_text().split('\n') {
+            let line = if !text_line.contains("http://") && !text_line.contains("https://") {
+                // Fast path: no URL prefix — single span, no allocation
+                Line::from(Span::styled(
+                    text_line.to_string(),
+                    Style::default().fg(msg_color),
+                ))
+            } else {
+                let spans: Vec<Span> = split_line_with_urls(text_line)
+                    .into_iter()
+                    .map(|(seg, is_url)| {
+                        if is_url {
+                            Span::styled(seg.to_string(), url_style)
+                        } else {
+                            Span::styled(seg.to_string(), Style::default().fg(msg_color))
+                        }
+                    })
+                    .collect();
+                Line::from(spans)
+            };
+            if msg.is_outgoing {
+                lines.push(line.alignment(Alignment::Right));
+            } else {
+                lines.push(line);
+            }
+        }
+```
+
+- [ ] **Step 7: Run tests**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat && cargo test 2>&1
+```
+
+Expected: `test result: ok. 22 passed`
+
+- [ ] **Step 8: Smoke test**
+
+```bash
+cargo run
+```
+
+Verify visually:
+- Outgoing messages: header shows `"HH:MM  You"` right-aligned at the right edge; message text is right-aligned
+- Incoming messages: unchanged (left-aligned, sender then time)
+- Group chat entries in the chat list show `[GP]` in magenta instead of `[WA]`/`[TG]`
+- Newsletter entries still show `[NL]` in cyan
+
+**Known limitation:** ratatui word-wraps long lines before applying alignment. If an outgoing message is wide enough to wrap, only the first visual sub-line will be right-aligned; continuation lines will appear left-aligned. This is acceptable for typical short chat messages.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/tui/widgets/message_view.rs
+git commit -m "feat: right-align outgoing messages in message view"
+```

--- a/docs/superpowers/specs/2026-03-10-bracketed-paste-design.md
+++ b/docs/superpowers/specs/2026-03-10-bracketed-paste-design.md
@@ -1,0 +1,53 @@
+# Bracketed Paste Support
+
+**Date:** 2026-03-10
+**Issue:** [#14 — pasting multi-line text sends each line as a separate message](https://github.com/mgblackwater/zero-drift-chat/issues/14)
+
+## Problem
+
+When `enter_sends = true` (default), pasting multi-line text into the chat input sends each line as a separate message. The terminal in raw mode emits pasted newlines as plain `Enter` key events, which the key handler maps to `SubmitMessage`.
+
+## Root Cause
+
+`src/tui/event.rs` only forwards `Event::Key` and `Event::Resize` events; `Event::Paste` falls through to `_ => {}` and is discarded. No bracketed paste mode is enabled, so the terminal never signals the start/end of a paste sequence.
+
+## Design
+
+Enable bracketed paste mode so the terminal wraps pasted content in escape sequences. Crossterm exposes this as `Event::Paste(String)`. Capture that event and insert the text directly into the `TextArea`, bypassing the Enter key handler entirely.
+
+### Changes
+
+| File | Change |
+|------|--------|
+| `src/app.rs` | Enable `EnableBracketedPaste` on startup; disable in cleanup and panic hook |
+| `src/tui/event.rs` | Add `Paste(String)` variant to `AppEvent` |
+| `src/tui/event.rs` | Match `Event::Paste(text)` in the event loop, send `AppEvent::Paste(text)` |
+| `src/app.rs` | Handle `AppEvent::Paste(text)` — call `input.insert_str(&text)` when in editing mode |
+
+### Paste handler behaviour
+
+```rust
+AppEvent::Paste(text) => {
+    if self.state.input_mode == InputMode::Editing {
+        self.state.input.insert_str(&text);
+        self.state.ai_suggestion = None;
+        if self.ai_worker.is_some() {
+            self.last_keystroke = Some(Instant::now());
+        }
+    }
+}
+```
+
+### Non-changes
+
+- `keybindings.rs` — untouched; typed Enter still submits
+- `tui-textarea` — no changes; `insert_str` is a stable API
+- No new dependencies
+
+## Testing
+
+- Paste multi-line text → full block appears in input, not sent
+- Type Enter after paste → message sent as one unit
+- Paste in Normal mode → ignored (no crash)
+- Ctrl+S after paste → submits as expected
+- `enter_sends = false` mode → same paste behaviour, submit via Shift+Enter

--- a/docs/superpowers/specs/2026-03-10-message-layout-group-indicator-design.md
+++ b/docs/superpowers/specs/2026-03-10-message-layout-group-indicator-design.md
@@ -1,0 +1,35 @@
+# Message Layout + Group Chat Indicator Design
+
+**Date:** 2026-03-10
+
+## Features
+
+### 1. Right-aligned outgoing messages
+
+Outgoing messages (where `msg.is_outgoing == true`) are rendered right-justified inside the message view panel.
+
+**Header line:** rendered as `timestamp  SenderName` and padded with leading spaces to push it to the right edge of the panel width.
+
+**Content lines:** each line padded with leading spaces so the text ends at the right edge of the panel width.
+
+Incoming messages are unchanged (left-aligned as today). Colors stay the same (green sender, white text for outgoing).
+
+**File:** `src/tui/widgets/message_view.rs`
+
+### 2. Group chat `[GP]` indicator in chat list
+
+In the chat list, if `chat.is_group == true`, render `[GP]` in **Magenta** instead of the platform tag (`[WA]`/`[TG]`/`[SL]`).
+
+`[GP]` takes priority over the platform tag, the same way `[NL]` (newsletter, Cyan) does today. The precedence order becomes:
+
+1. `[NL]` in Cyan — if `chat.is_newsletter`
+2. `[GP]` in Magenta — else if `chat.is_group`
+3. Platform tag in DarkGray — otherwise
+
+**File:** `src/tui/widgets/chat_list.rs`
+
+## Non-changes
+
+- No new fields on `UnifiedMessage` or `UnifiedChat` — `is_group` already exists on `UnifiedChat`
+- No color changes to message bubbles inside group chats
+- No changes to any provider code

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 
 use crossterm::{
     execute,
+    event::{DisableBracketedPaste, EnableBracketedPaste},
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen, SetTitle},
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
@@ -171,7 +172,7 @@ impl App {
         // Set up terminal
         enable_raw_mode()?;
         let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen)?;
+        execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
         let backend = CrosstermBackend::new(stdout);
         let mut terminal = Terminal::new(backend)?;
 
@@ -179,7 +180,7 @@ impl App {
         let original_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |panic_info| {
             let _ = disable_raw_mode();
-            let _ = execute!(io::stdout(), LeaveAlternateScreen);
+            let _ = execute!(io::stdout(), DisableBracketedPaste, LeaveAlternateScreen);
             original_hook(panic_info);
         }));
 
@@ -247,6 +248,15 @@ impl App {
                 Some(AppEvent::Resize(_, _)) => {
                     // Terminal handles resize automatically
                 }
+                Some(AppEvent::Paste(text)) => {
+                    if self.state.input_mode == InputMode::Editing {
+                        self.state.input.insert_str(&text);
+                        self.state.ai_suggestion = None;
+                        if self.ai_worker.is_some() {
+                            self.last_keystroke = Some(Instant::now());
+                        }
+                    }
+                }
                 Some(AppEvent::AiSuggestion(text)) => {
                     if self.state.input_mode == InputMode::Editing {
                         tracing::info!(suggestion = %text, "AI autocomplete suggestion received");
@@ -271,6 +281,7 @@ impl App {
         disable_raw_mode()?;
         execute!(
             terminal.backend_mut(),
+            DisableBracketedPaste,
             LeaveAlternateScreen
         )?;
         Self::update_title(false);   // restore clean title on exit

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 #[derive(Debug)]
 pub enum AppEvent {
     Key(crossterm::event::KeyEvent),
+    Paste(String),
     Resize(u16, u16),
     Tick,
     Render,
@@ -53,6 +54,11 @@ impl EventHandler {
                                     if task_tx.send(AppEvent::Key(key)).is_err() {
                                         break;
                                     }
+                                }
+                            }
+                            Event::Paste(text) => {
+                                if task_tx.send(AppEvent::Paste(text)).is_err() {
+                                    break;
                                 }
                             }
                             Event::Resize(w, h) => {

--- a/src/tui/widgets/chat_list.rs
+++ b/src/tui/widgets/chat_list.rs
@@ -33,6 +33,8 @@ fn make_item(chat: &UnifiedChat, is_selected: bool) -> ListItem<'static> {
     ];
     if chat.is_newsletter {
         spans.push(Span::styled("[NL]", Style::default().fg(Color::Cyan)));
+    } else if chat.is_group {
+        spans.push(Span::styled("[GP]", Style::default().fg(Color::Magenta)));
     } else {
         spans.push(Span::styled(tag, Style::default().fg(Color::DarkGray)));
     }

--- a/src/tui/widgets/message_view.rs
+++ b/src/tui/widgets/message_view.rs
@@ -1,6 +1,6 @@
 use chrono::Local;
 use ratatui::{
-    layout::Rect,
+    layout::{Alignment, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
@@ -123,13 +123,26 @@ pub fn render_message_view(
             (Color::Cyan, Color::Gray)
         };
 
-        let header = Line::from(vec![
-            Span::styled(
-                format!("{} ", msg.sender),
-                Style::default().fg(sender_color),
-            ),
-            Span::styled(time, Style::default().fg(Color::DarkGray)),
-        ]);
+        let header = if msg.is_outgoing {
+            // Right-aligned: "10:02  You" pushed to the right edge
+            Line::from(vec![
+                Span::styled(time, Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!("  {}", msg.sender),
+                    Style::default().fg(sender_color),
+                ),
+            ])
+            .alignment(Alignment::Right)
+        } else {
+            // Left-aligned: "You 10:02" (unchanged)
+            Line::from(vec![
+                Span::styled(
+                    format!("{} ", msg.sender),
+                    Style::default().fg(sender_color),
+                ),
+                Span::styled(time, Style::default().fg(Color::DarkGray)),
+            ])
+        };
 
         lines.push(header);
         let url_style = Style::default()
@@ -137,25 +150,30 @@ pub fn render_message_view(
             .add_modifier(Modifier::UNDERLINED);
 
         for text_line in msg.content.as_text().split('\n') {
-            if !text_line.contains("http://") && !text_line.contains("https://") {
+            let line = if !text_line.contains("http://") && !text_line.contains("https://") {
                 // Fast path: no URL prefix — single span, no allocation
-                lines.push(Line::from(Span::styled(
+                Line::from(Span::styled(
                     text_line.to_string(),
                     Style::default().fg(msg_color),
-                )));
-                continue;
+                ))
+            } else {
+                let spans: Vec<Span> = split_line_with_urls(text_line)
+                    .into_iter()
+                    .map(|(seg, is_url)| {
+                        if is_url {
+                            Span::styled(seg.to_string(), url_style)
+                        } else {
+                            Span::styled(seg.to_string(), Style::default().fg(msg_color))
+                        }
+                    })
+                    .collect();
+                Line::from(spans)
+            };
+            if msg.is_outgoing {
+                lines.push(line.alignment(Alignment::Right));
+            } else {
+                lines.push(line);
             }
-            let spans: Vec<Span> = split_line_with_urls(text_line)
-                .into_iter()
-                .map(|(seg, is_url)| {
-                    if is_url {
-                        Span::styled(seg.to_string(), url_style)
-                    } else {
-                        Span::styled(seg.to_string(), Style::default().fg(msg_color))
-                    }
-                })
-                .collect();
-            lines.push(Line::from(spans));
         }
         lines.push(Line::from("")); // spacing
     }


### PR DESCRIPTION
## Summary

- **fix:** Enable bracketed paste mode so pasting multi-line text inserts the full block as one message instead of sending each line separately (closes #14)
- **feat:** Right-align outgoing messages — header shows `HH:MM  You` at the right edge; message text is right-aligned
- **feat:** Show `[GP]` in magenta for group chats in the chat list, following the same pattern as `[NL]` for newsletters

## Details

### Bracketed paste fix
Enables `EnableBracketedPaste` on terminal startup and `DisableBracketedPaste` on teardown (both normal exit and panic hook). Crossterm's `Event::Paste(String)` is captured in the event loop and forwarded as a new `AppEvent::Paste(String)` variant, then inserted directly into the `TextArea` via `insert_str`, bypassing the Enter key handler entirely.

### Right-aligned outgoing messages
Uses ratatui 0.29's `Line::alignment(Alignment::Right)` on outgoing message headers and content lines. The header span order is reversed for outgoing messages (`time  sender`) so it reads naturally when right-justified.

### Group chat indicator
Adds an `else if chat.is_group` branch between the existing `[NL]` and platform-tag branches in `make_item`, rendering `[GP]` in `Color::Magenta`.

## Test Plan
- [ ] Paste multi-line text → full block appears in input, not sent line-by-line
- [ ] Outgoing messages appear right-aligned; incoming messages unchanged
- [ ] Group chats show `[GP]` in magenta; newsletters still show `[NL]` in cyan; 1:1 chats show platform tag
- [ ] `cargo test` — 22 tests pass