### PR TITLE
feat: message copy — quick-copy last (y) and select-mode copy (v)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.3.2 — 2026-03-11
+
+### Copy messages to clipboard
+
+- Press `y` in Normal mode to instantly copy the **last message** in the current chat to the clipboard
+- Press `v` in Normal mode to enter **Message Select mode** — a vim-style selection overlay
+  - `j` / `↓` and `k` / `↑` navigate between messages; the selected message is highlighted with a cyan `▌` gutter and blue background
+  - `y` or `Enter` copies the selected message text and exits Select mode
+  - `Esc` / `q` cancels without copying
+- Clipboard is written via the **OSC 52** terminal escape sequence — works in any modern terminal (kitty, iTerm2, tmux with `set-clipboard on`, etc.) without external tools
+- A brief **"Copied!"** flash appears in the status bar to confirm the copy
+
 ## v0.3.1 — 2026-03-05
 
 - Newsletter chats (`@newsletter` JIDs) now show a `[NL]` tag and are excluded from the unread count header

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -16,3 +16,10 @@
 - In-app settings overlay — toggle providers and log level without editing files
 - Chat rename — press `r` to set custom display names (persisted across restarts)
 - Version displayed in status bar
+
+## Copy to Clipboard
+- Press `y` to copy the last message in the current chat to the clipboard
+- Press `v` to enter **Message Select mode**: navigate with `j`/`k`, copy with `y` or `Enter`, cancel with `Esc`
+- Uses OSC 52 terminal escape sequence — no external clipboard tool required
+- Works in kitty, iTerm2, and tmux (with `set-clipboard on`)
+- Confirmation flash "Copied!" shown in the status bar

--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ On first launch with WhatsApp enabled, a QR code appears. Scan it with WhatsApp 
 | `i` / `Enter` | Start typing |
 | `r` | Rename selected chat |
 | `s` | Open settings |
+| `/` | Open chat search |
 | `PgUp` / `PgDn` | Scroll messages |
+| `y` | Copy last message to clipboard |
+| `v` | Enter Message Select mode |
 | `q` | Quit |
 
 **Insert mode:**
@@ -73,6 +76,24 @@ On first launch with WhatsApp enabled, a QR code appears. Scan it with WhatsApp 
 | `← →` / `Home` / `End` | Move cursor |
 | `Ctrl+U` | Clear input |
 | `Esc` | Back to normal mode |
+
+**Message Select mode** (`v` from Normal mode):
+
+Navigate the message list and copy any message to your clipboard.
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Select next message (newer) |
+| `k` / `↑` | Select previous message (older) |
+| `y` / `Enter` | Copy selected message and exit |
+| `Esc` / `q` | Cancel without copying |
+
+The selected message is highlighted with a cyan `▌` gutter and blue background.
+Copying uses the **OSC 52** terminal escape sequence so no external tool is needed.
+A brief **"Copied!"** confirmation flashes in the status bar.
+
+> **Terminal support:** OSC 52 works out of the box in kitty, iTerm2, and WezTerm.
+> In tmux, enable it with `set -g set-clipboard on` in your `~/.tmux.conf`.
 
 **Settings overlay:**
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -291,6 +291,9 @@ impl App {
     }
 
     fn handle_tick(&mut self) {
+        // Clear transient copy status after one tick so it disappears quickly
+        self.state.copy_status = None;
+
         let events = self.router.poll_events();
 
         // Cap events per tick to avoid blocking the render loop
@@ -790,6 +793,35 @@ impl App {
                     }
                 }
             }
+            Action::CopyLastMessage => {
+                if let Some(msg) = self.state.messages.last() {
+                    let text = msg.content.as_text().to_string();
+                    copy_to_clipboard(&text);
+                    self.state.copy_status = Some("Copied!".to_string());
+                }
+            }
+            Action::EnterMessageSelect => {
+                self.state.enter_message_select();
+            }
+            Action::MessageSelectPrev => {
+                self.state.message_select_prev();
+            }
+            Action::MessageSelectNext => {
+                self.state.message_select_next();
+            }
+            Action::MessageSelectCopy => {
+                if let Some(idx) = self.state.selected_message_idx {
+                    if let Some(msg) = self.state.messages.get(idx) {
+                        let text = msg.content.as_text().to_string();
+                        copy_to_clipboard(&text);
+                        self.state.copy_status = Some("Copied!".to_string());
+                    }
+                }
+                self.state.exit_message_select();
+            }
+            Action::MessageSelectExit => {
+                self.state.exit_message_select();
+            }
             Action::None => {}
         }
     }
@@ -895,4 +927,40 @@ impl App {
         }
         None
     }
+}
+
+/// Copy text to the system clipboard using the OSC 52 terminal escape sequence.
+/// This works in most modern terminals (kitty, iTerm2, WezTerm, tmux with set-clipboard on, etc.).
+fn copy_to_clipboard(text: &str) {
+    use std::io::Write;
+    let encoded = base64_encode(text.as_bytes());
+    // OSC 52 ; c ; <base64> ST
+    let osc52 = format!("\x1b]52;c;{}\x07", encoded);
+    let _ = std::io::stdout().write_all(osc52.as_bytes());
+    let _ = std::io::stdout().flush();
+}
+
+/// Minimal base64 encoder (no external crate needed).
+fn base64_encode(input: &[u8]) -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity((input.len() + 2) / 3 * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as u32;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+        out.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+        if chunk.len() > 1 {
+            out.push(ALPHABET[((n >> 6) & 0x3f) as usize] as char);
+        } else {
+            out.push('=');
+        }
+        if chunk.len() > 2 {
+            out.push(ALPHABET[(n & 0x3f) as usize] as char);
+        } else {
+            out.push('=');
+        }
+    }
+    out
 }

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -12,6 +12,7 @@ pub enum InputMode {
     Renaming,
     ChatMenu,
     Searching,
+    MessageSelect,
 }
 
 // --- Settings overlay types ---
@@ -140,10 +141,18 @@ impl ChatMenuItem {
     pub fn label(&self, is_pinned: bool, is_muted: bool) -> &'static str {
         match self {
             ChatMenuItem::TogglePin => {
-                if is_pinned { "Unpin" } else { "Pin" }
+                if is_pinned {
+                    "Unpin"
+                } else {
+                    "Pin"
+                }
             }
             ChatMenuItem::ToggleMute => {
-                if is_muted { "Unmute" } else { "Mute" }
+                if is_muted {
+                    "Unmute"
+                } else {
+                    "Mute"
+                }
             }
         }
     }
@@ -186,13 +195,17 @@ impl ChatMenuState {
 #[derive(Debug, Clone)]
 pub struct SearchState {
     pub query: String,
-    pub results: Vec<usize>,  // indices into AppState::chats (top 5)
-    pub selected: usize,      // currently highlighted result index
+    pub results: Vec<usize>, // indices into AppState::chats (top 5)
+    pub selected: usize,     // currently highlighted result index
 }
 
 impl SearchState {
     pub fn new() -> Self {
-        Self { query: String::new(), results: vec![], selected: 0 }
+        Self {
+            query: String::new(),
+            results: vec![],
+            selected: 0,
+        }
     }
 }
 
@@ -224,6 +237,10 @@ pub struct AppState {
     pub enter_sends: bool,
     /// Number of unread messages at the tail of `messages` when a chat was opened.
     pub new_message_count: usize,
+    /// Transient copy feedback: Some("Copied!") briefly after y is pressed.
+    pub copy_status: Option<String>,
+    /// Index into `messages` of the currently highlighted message in MessageSelect mode.
+    pub selected_message_idx: Option<usize>,
 }
 
 impl AppState {
@@ -252,6 +269,8 @@ impl AppState {
             ai_debug_log: Vec::new(),
             enter_sends: true,
             new_message_count: 0,
+            copy_status: None,
+            selected_message_idx: None,
         }
     }
 
@@ -343,7 +362,9 @@ impl AppState {
             if let Some(chat) = self.chats.get(idx) {
                 self.chat_menu_state = Some(ChatMenuState::new(
                     chat.id.clone(),
-                    chat.display_name.clone().unwrap_or_else(|| chat.name.clone()),
+                    chat.display_name
+                        .clone()
+                        .unwrap_or_else(|| chat.name.clone()),
                     chat.is_pinned,
                     chat.is_muted,
                 ));
@@ -368,5 +389,39 @@ impl AppState {
 
     pub fn has_unread(&self) -> bool {
         self.chats.iter().any(|c| !c.is_muted && c.unread_count > 0)
+    }
+
+    /// Enter message-selection mode, starting at the last message.
+    pub fn enter_message_select(&mut self) {
+        if self.messages.is_empty() {
+            return;
+        }
+        self.selected_message_idx = Some(self.messages.len() - 1);
+        self.input_mode = InputMode::MessageSelect;
+        self.active_panel = ActivePanel::MessageView;
+    }
+
+    /// Exit message-selection mode.
+    pub fn exit_message_select(&mut self) {
+        self.selected_message_idx = None;
+        self.input_mode = InputMode::Normal;
+    }
+
+    /// Move selection up (toward older messages).
+    pub fn message_select_prev(&mut self) {
+        if let Some(idx) = self.selected_message_idx {
+            if idx > 0 {
+                self.selected_message_idx = Some(idx - 1);
+            }
+        }
+    }
+
+    /// Move selection down (toward newer messages).
+    pub fn message_select_next(&mut self) {
+        if let Some(idx) = self.selected_message_idx {
+            if idx + 1 < self.messages.len() {
+                self.selected_message_idx = Some(idx + 1);
+            }
+        }
     }
 }

--- a/src/tui/keybindings.rs
+++ b/src/tui/keybindings.rs
@@ -35,19 +35,26 @@ pub enum Action {
     SearchPrev,
     SearchConfirm,
     SearchClose,
-    AiSuggestAccept,   // Tab — accept ghost text suggestion
-    AiSuggestRequest,  // Ctrl+Space — on-demand trigger
+    AiSuggestAccept,    // Tab — accept ghost text suggestion
+    AiSuggestRequest,   // Ctrl+Space — on-demand trigger
+    CopyLastMessage,    // y — copy last message text to clipboard via OSC 52
+    EnterMessageSelect, // v — enter message selection mode
+    MessageSelectPrev,  // k/Up — move selection up (older)
+    MessageSelectNext,  // j/Down — move selection down (newer)
+    MessageSelectCopy,  // y — copy selected message and exit
+    MessageSelectExit,  // Esc — exit without copying
     None,
 }
 
 pub fn map_key(key: KeyEvent, mode: InputMode, enter_sends: bool) -> Action {
     match mode {
-        InputMode::Normal   => map_normal_mode(key),
-        InputMode::Editing  => map_editing_mode(key, enter_sends),
+        InputMode::Normal => map_normal_mode(key),
+        InputMode::Editing => map_editing_mode(key, enter_sends),
         InputMode::Settings => map_settings_mode(key),
         InputMode::Renaming => map_renaming_mode(key),
         InputMode::ChatMenu => map_chat_menu_mode(key),
         InputMode::Searching => map_search_mode(key),
+        InputMode::MessageSelect => map_message_select_mode(key),
     }
 }
 
@@ -63,6 +70,8 @@ fn map_normal_mode(key: KeyEvent) -> Action {
         KeyCode::Char('r') => Action::RenameChat,
         KeyCode::Char('x') => Action::OpenChatMenu,
         KeyCode::Char('/') => Action::OpenSearch,
+        KeyCode::Char('y') => Action::CopyLastMessage,
+        KeyCode::Char('v') => Action::EnterMessageSelect,
         KeyCode::PageUp => Action::ScrollUp,
         KeyCode::PageDown => Action::ScrollDown,
         _ => Action::None,
@@ -74,16 +83,16 @@ fn map_editing_mode(key: KeyEvent, enter_sends: bool) -> Action {
         (KeyCode::Esc, _) => Action::ExitEditing,
 
         // enter_sends=true (default): plain Enter submits, Shift/Alt+Enter inserts newline
-        (KeyCode::Enter, m)
-            if enter_sends && m == KeyModifiers::NONE => Action::SubmitMessage,
-        (KeyCode::Enter, _)
-            if enter_sends => Action::InputKey(key), // Shift/Alt+Enter → forward to textarea as newline
+        (KeyCode::Enter, m) if enter_sends && m == KeyModifiers::NONE => Action::SubmitMessage,
+        (KeyCode::Enter, _) if enter_sends => Action::InputKey(key), // Shift/Alt+Enter → forward to textarea as newline
 
         // enter_sends=false: Shift/Alt+Enter submits, plain Enter inserts newline
-        (KeyCode::Enter, m)
-            if !enter_sends && m.contains(KeyModifiers::SHIFT) => Action::SubmitMessage,
-        (KeyCode::Enter, m)
-            if !enter_sends && m.contains(KeyModifiers::ALT) => Action::SubmitMessage,
+        (KeyCode::Enter, m) if !enter_sends && m.contains(KeyModifiers::SHIFT) => {
+            Action::SubmitMessage
+        }
+        (KeyCode::Enter, m) if !enter_sends && m.contains(KeyModifiers::ALT) => {
+            Action::SubmitMessage
+        }
 
         // Ctrl+J: WSL-friendly newline insert (Shift+Enter not reliably transmitted in WSL)
         (KeyCode::Char('j'), m) if m.contains(KeyModifiers::CONTROL) => {
@@ -139,5 +148,15 @@ fn map_renaming_mode(key: KeyEvent) -> Action {
         // Block Shift+Enter / Alt+Enter from inserting newlines into a chat name
         (KeyCode::Enter, _) => Action::None,
         _ => Action::InputKey(key),
+    }
+}
+
+fn map_message_select_mode(key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Char('k') | KeyCode::Up => Action::MessageSelectPrev,
+        KeyCode::Char('j') | KeyCode::Down => Action::MessageSelectNext,
+        KeyCode::Char('y') | KeyCode::Enter => Action::MessageSelectCopy,
+        KeyCode::Esc | KeyCode::Char('q') => Action::MessageSelectExit,
+        _ => Action::None,
     }
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -7,7 +7,9 @@ use ratatui::{
 };
 
 use super::app_state::{AppState, InputMode};
-use super::widgets::{self, chat_list, input_bar, message_view, qr_overlay, settings_overlay, status_bar};
+use super::widgets::{
+    self, chat_list, input_bar, message_view, qr_overlay, settings_overlay, status_bar,
+};
 
 pub fn draw(f: &mut Frame, state: &mut AppState) {
     let outer = Layout::default()
@@ -67,6 +69,7 @@ pub fn draw(f: &mut Frame, state: &mut AppState) {
         state.scroll_offset,
         state.active_panel,
         state.new_message_count,
+        state.selected_message_idx,
     );
 
     input_bar::render_input_bar(
@@ -85,22 +88,27 @@ pub fn draw(f: &mut Frame, state: &mut AppState) {
                 Style::default().fg(Color::DarkGray),
             ))]
         } else {
-            state.ai_debug_log.iter().map(|entry| {
-                let color = if entry.starts_with("[error]") {
-                    Color::Red
-                } else if entry.starts_with("[suggestion]") {
-                    Color::Green
-                } else {
-                    Color::Cyan
-                };
-                Line::from(Span::styled(entry.as_str(), Style::default().fg(color)))
-            }).collect()
+            state
+                .ai_debug_log
+                .iter()
+                .map(|entry| {
+                    let color = if entry.starts_with("[error]") {
+                        Color::Red
+                    } else if entry.starts_with("[suggestion]") {
+                        Color::Green
+                    } else {
+                        Color::Cyan
+                    };
+                    Line::from(Span::styled(entry.as_str(), Style::default().fg(color)))
+                })
+                .collect()
         };
-        let debug_widget = Paragraph::new(log_lines)
-            .block(Block::default()
+        let debug_widget = Paragraph::new(log_lines).block(
+            Block::default()
                 .title(" AI Debug ")
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::DarkGray)));
+                .border_style(Style::default().fg(Color::DarkGray)),
+        );
         f.render_widget(debug_widget, debug_area);
     }
 
@@ -111,6 +119,7 @@ pub fn draw(f: &mut Frame, state: &mut AppState) {
         state.enter_sends,
         state.mock_enabled,
         state.whatsapp_connected,
+        state.copy_status.as_deref(),
     );
 
     // Render QR code overlay on top if present

--- a/src/tui/widgets/input_bar.rs
+++ b/src/tui/widgets/input_bar.rs
@@ -16,12 +16,13 @@ pub fn render_input_bar(
     ai_suggestion: Option<&str>,
 ) {
     let (mode_tag, border_color, title_align) = match mode {
-        InputMode::Normal   => ("NORMAL",   Color::DarkGray, Alignment::Left),
-        InputMode::Editing  => ("✏  INSERT", Color::Yellow,   Alignment::Center),
-        InputMode::Settings => ("SETTINGS", Color::Cyan,     Alignment::Left),
-        InputMode::Renaming => ("RENAME",   Color::Magenta,  Alignment::Left),
-        InputMode::ChatMenu => ("MENU",     Color::Yellow,   Alignment::Left),
-        InputMode::Searching => ("SEARCH",  Color::Cyan,     Alignment::Left),
+        InputMode::Normal => ("NORMAL", Color::DarkGray, Alignment::Left),
+        InputMode::Editing => ("✏  INSERT", Color::Yellow, Alignment::Center),
+        InputMode::Settings => ("SETTINGS", Color::Cyan, Alignment::Left),
+        InputMode::Renaming => ("RENAME", Color::Magenta, Alignment::Left),
+        InputMode::ChatMenu => ("MENU", Color::Yellow, Alignment::Left),
+        InputMode::Searching => ("SEARCH", Color::Cyan, Alignment::Left),
+        InputMode::MessageSelect => ("SELECT", Color::Blue, Alignment::Left),
     };
 
     let block = Block::default()
@@ -49,8 +50,7 @@ pub fn render_input_bar(
                     };
                     let hint_text = format!("  ↳ {}", suggestion);
                     f.render_widget(
-                        Paragraph::new(hint_text)
-                            .style(Style::default().fg(Color::DarkGray)),
+                        Paragraph::new(hint_text).style(Style::default().fg(Color::DarkGray)),
                         hint_area,
                     );
                 }

--- a/src/tui/widgets/message_view.rs
+++ b/src/tui/widgets/message_view.rs
@@ -135,8 +135,8 @@ pub fn render_message_view(
             Style::default()
         };
 
-        // Left gutter marker: "▌ " for selected, "  " otherwise (keeps alignment)
-        let gutter = if is_selected { "▌ " } else { "  " };
+        // Left gutter marker: only shown when this message is selected
+        let gutter = "▌ ";
         let gutter_style = Style::default().fg(Color::Cyan).bg(Color::Blue);
 
         let header = if msg.is_outgoing {
@@ -156,12 +156,21 @@ pub fn render_message_view(
                 .alignment(Alignment::Right);
             }
             line
-        } else {
-            // Left-aligned: gutter + "Sender HH:MM"
+        } else if is_selected {
+            // Left-aligned selected: cyan gutter + highlighted sender + time
             Line::from(vec![
                 Span::styled(gutter, gutter_style),
                 Span::styled(format!("{} ", msg.sender), select_bg.fg(sender_color)),
                 Span::styled(time, select_bg.fg(Color::DarkGray)),
+            ])
+        } else {
+            // Left-aligned normal: no gutter
+            Line::from(vec![
+                Span::styled(
+                    format!("{} ", msg.sender),
+                    Style::default().fg(sender_color),
+                ),
+                Span::styled(time, Style::default().fg(Color::DarkGray)),
             ])
         };
 

--- a/src/tui/widgets/message_view.rs
+++ b/src/tui/widgets/message_view.rs
@@ -51,7 +51,6 @@ fn split_line_with_urls(line: &str) -> Vec<(&str, bool)> {
     result
 }
 
-
 pub fn render_message_view(
     f: &mut Frame,
     area: Rect,
@@ -60,6 +59,7 @@ pub fn render_message_view(
     scroll_offset: u16,
     active_panel: ActivePanel,
     new_message_count: usize,
+    selected_message_idx: Option<usize>,
 ) {
     let border_color = if active_panel == ActivePanel::MessageView {
         Color::Cyan
@@ -112,8 +112,13 @@ pub fn render_message_view(
             lines.push(Line::styled(separator, Style::default().fg(Color::Yellow)));
         }
 
-        let time = msg.timestamp.with_timezone(&Local).format("%H:%M").to_string();
+        let time = msg
+            .timestamp
+            .with_timezone(&Local)
+            .format("%H:%M")
+            .to_string();
         let is_new = new_start_idx.map(|s| i >= s).unwrap_or(false) && !msg.is_outgoing;
+        let is_selected = selected_message_idx == Some(i);
 
         let (sender_color, msg_color) = if msg.is_outgoing {
             (Color::Green, Color::White)
@@ -123,24 +128,40 @@ pub fn render_message_view(
             (Color::Cyan, Color::Gray)
         };
 
+        // Selection highlight style applied to every span in the selected message
+        let select_bg = if is_selected {
+            Style::default().bg(Color::Blue)
+        } else {
+            Style::default()
+        };
+
+        // Left gutter marker: "▌ " for selected, "  " otherwise (keeps alignment)
+        let gutter = if is_selected { "▌ " } else { "  " };
+        let gutter_style = Style::default().fg(Color::Cyan).bg(Color::Blue);
+
         let header = if msg.is_outgoing {
             // Right-aligned: "10:02  You" pushed to the right edge
-            Line::from(vec![
-                Span::styled(time, Style::default().fg(Color::DarkGray)),
-                Span::styled(
-                    format!("  {}", msg.sender),
-                    Style::default().fg(sender_color),
-                ),
+            let mut line = Line::from(vec![
+                Span::styled(time.clone(), select_bg.fg(Color::DarkGray)),
+                Span::styled(format!("  {}", msg.sender), select_bg.fg(sender_color)),
             ])
-            .alignment(Alignment::Right)
+            .alignment(Alignment::Right);
+            if is_selected {
+                // For outgoing selected, append a trailing marker on the right
+                line = Line::from(vec![
+                    Span::styled(time, select_bg.fg(Color::DarkGray)),
+                    Span::styled(format!("  {}", msg.sender), select_bg.fg(sender_color)),
+                    Span::styled(" ▐", Style::default().fg(Color::Cyan).bg(Color::Blue)),
+                ])
+                .alignment(Alignment::Right);
+            }
+            line
         } else {
-            // Left-aligned: "You 10:02" (unchanged)
+            // Left-aligned: gutter + "Sender HH:MM"
             Line::from(vec![
-                Span::styled(
-                    format!("{} ", msg.sender),
-                    Style::default().fg(sender_color),
-                ),
-                Span::styled(time, Style::default().fg(Color::DarkGray)),
+                Span::styled(gutter, gutter_style),
+                Span::styled(format!("{} ", msg.sender), select_bg.fg(sender_color)),
+                Span::styled(time, select_bg.fg(Color::DarkGray)),
             ])
         };
 
@@ -151,22 +172,66 @@ pub fn render_message_view(
 
         for text_line in msg.content.as_text().split('\n') {
             let line = if !text_line.contains("http://") && !text_line.contains("https://") {
-                // Fast path: no URL prefix — single span, no allocation
-                Line::from(Span::styled(
-                    text_line.to_string(),
-                    Style::default().fg(msg_color),
-                ))
+                if is_selected && !msg.is_outgoing {
+                    Line::from(vec![
+                        Span::styled(gutter, gutter_style),
+                        Span::styled(text_line.to_string(), select_bg.fg(msg_color)),
+                    ])
+                } else if is_selected {
+                    Line::from(Span::styled(text_line.to_string(), select_bg.fg(msg_color)))
+                } else {
+                    Line::from(Span::styled(
+                        text_line.to_string(),
+                        Style::default().fg(msg_color),
+                    ))
+                }
             } else {
-                let spans: Vec<Span> = split_line_with_urls(text_line)
-                    .into_iter()
-                    .map(|(seg, is_url)| {
-                        if is_url {
-                            Span::styled(seg.to_string(), url_style)
-                        } else {
-                            Span::styled(seg.to_string(), Style::default().fg(msg_color))
-                        }
-                    })
-                    .collect();
+                let spans: Vec<Span> =
+                    if is_selected && !msg.is_outgoing {
+                        let mut s = vec![Span::styled(gutter, gutter_style)];
+                        s.extend(split_line_with_urls(text_line).into_iter().map(
+                            |(seg, is_url)| {
+                                if is_url {
+                                    Span::styled(
+                                        seg.to_string(),
+                                        select_bg
+                                            .fg(Color::LightBlue)
+                                            .add_modifier(Modifier::UNDERLINED),
+                                    )
+                                } else {
+                                    Span::styled(seg.to_string(), select_bg.fg(msg_color))
+                                }
+                            },
+                        ));
+                        s
+                    } else {
+                        split_line_with_urls(text_line)
+                            .into_iter()
+                            .map(|(seg, is_url)| {
+                                if is_url {
+                                    Span::styled(
+                                        seg.to_string(),
+                                        if is_selected {
+                                            select_bg
+                                                .fg(Color::LightBlue)
+                                                .add_modifier(Modifier::UNDERLINED)
+                                        } else {
+                                            url_style
+                                        },
+                                    )
+                                } else {
+                                    Span::styled(
+                                        seg.to_string(),
+                                        if is_selected {
+                                            select_bg.fg(msg_color)
+                                        } else {
+                                            Style::default().fg(msg_color)
+                                        },
+                                    )
+                                }
+                            })
+                            .collect()
+                    };
                 Line::from(spans)
             };
             if msg.is_outgoing {
@@ -228,7 +293,10 @@ mod tests {
 
     #[test]
     fn plain_text_no_url() {
-        assert_eq!(split_line_with_urls("hello world"), vec![("hello world", false)]);
+        assert_eq!(
+            split_line_with_urls("hello world"),
+            vec![("hello world", false)]
+        );
     }
 
     #[test]
@@ -238,7 +306,10 @@ mod tests {
 
     #[test]
     fn single_url() {
-        assert_eq!(split_line_with_urls("https://example.com"), vec![("https://example.com", true)]);
+        assert_eq!(
+            split_line_with_urls("https://example.com"),
+            vec![("https://example.com", true)]
+        );
     }
 
     #[test]
@@ -261,7 +332,12 @@ mod tests {
     fn url_with_trailing_comma() {
         assert_eq!(
             split_line_with_urls("check https://example.com, and more"),
-            vec![("check ", false), ("https://example.com", true), (",", false), (" and more", false)]
+            vec![
+                ("check ", false),
+                ("https://example.com", true),
+                (",", false),
+                (" and more", false)
+            ]
         );
     }
 
@@ -281,7 +357,13 @@ mod tests {
 
     #[test]
     fn http_and_https_both_detected() {
-        assert_eq!(split_line_with_urls("http://a.com"), vec![("http://a.com", true)]);
-        assert_eq!(split_line_with_urls("https://a.com"), vec![("https://a.com", true)]);
+        assert_eq!(
+            split_line_with_urls("http://a.com"),
+            vec![("http://a.com", true)]
+        );
+        assert_eq!(
+            split_line_with_urls("https://a.com"),
+            vec![("https://a.com", true)]
+        );
     }
 }

--- a/src/tui/widgets/message_view.rs
+++ b/src/tui/widgets/message_view.rs
@@ -255,8 +255,12 @@ pub fn render_message_view(
     // Padding so the last message is never clipped by word-wrap miscalculation
     lines.push(Line::from(""));
     lines.push(Line::from(""));
+    lines.push(Line::from(""));
+    lines.push(Line::from(""));
 
-    // Auto-scroll: estimate total visual lines accounting for word-wrap
+    // Auto-scroll: estimate total visual lines accounting for word-wrap.
+    // We use ceiling division (no +1 per line) to avoid over-estimating, and
+    // rely on the 4 blank padding lines above to absorb any remaining error.
     let visible_height = area.height.saturating_sub(2) as usize; // subtract borders
     let content_width = area.width.saturating_sub(2) as usize; // subtract borders
     let total_lines: usize = lines
@@ -269,8 +273,8 @@ pub fn render_message_view(
             if line_width == 0 {
                 1
             } else {
-                // +1 accounts for ratatui word-wrap sometimes needing an extra line
-                1 + line_width / content_width
+                // ceiling division: how many rows does this line occupy after wrapping?
+                (line_width + content_width - 1) / content_width
             }
         })
         .sum();

--- a/src/tui/widgets/status_bar.rs
+++ b/src/tui/widgets/status_bar.rs
@@ -15,9 +15,10 @@ pub fn render_status_bar(
     enter_sends: bool,
     mock_enabled: bool,
     whatsapp_connected: bool,
+    copy_status: Option<&str>,
 ) {
     let hints = match mode {
-        InputMode::Normal => "q:Quit | i:Insert | s:Settings | r:Rename | x:Menu | Tab:Switch",
+        InputMode::Normal => "q:Quit | i:Insert | s:Settings | r:Rename | x:Menu | y:Copy last | v:Select msg | Tab:Switch",
         InputMode::Editing => {
             if enter_sends {
                 "Esc:Normal | Enter:Send | Shift+Enter/Ctrl+J:Newline | Ctrl+S:Send | Ctrl+U:Clear"
@@ -29,24 +30,35 @@ pub fn render_status_bar(
         InputMode::Renaming => "Enter:Confirm | Esc:Cancel | Type new name",
         InputMode::ChatMenu => "j/k:Navigate | p/Enter:Confirm | Esc:Close",
         InputMode::Searching => "Type to filter | j/k:Navigate | Enter:Open+Insert | Esc:Cancel",
+        InputMode::MessageSelect => "j/k:Navigate | y/Enter:Copy | Esc:Cancel",
     };
 
     // Mode pill: colored badge on the left, rest of bar stays on black
     let (pill_label, pill_bg, pill_fg) = match mode {
-        InputMode::Normal   => (" NORMAL ",  Color::DarkGray, Color::Black),
-        InputMode::Editing  => (" ✏ INSERT ", Color::Yellow,   Color::Black),
-        InputMode::Settings => (" SETTINGS ", Color::Cyan,    Color::Black),
-        InputMode::Renaming => (" RENAME ",  Color::Magenta,  Color::Black),
-        InputMode::ChatMenu => (" MENU ",    Color::Yellow,   Color::Black),
-        InputMode::Searching => (" SEARCH ", Color::Cyan,     Color::Black),
+        InputMode::Normal => (" NORMAL ", Color::DarkGray, Color::Black),
+        InputMode::Editing => (" ✏ INSERT ", Color::Yellow, Color::Black),
+        InputMode::Settings => (" SETTINGS ", Color::Cyan, Color::Black),
+        InputMode::Renaming => (" RENAME ", Color::Magenta, Color::Black),
+        InputMode::ChatMenu => (" MENU ", Color::Yellow, Color::Black),
+        InputMode::Searching => (" SEARCH ", Color::Cyan, Color::Black),
+        InputMode::MessageSelect => (" SELECT ", Color::Blue, Color::White),
     };
 
     let sep = Style::default().fg(Color::DarkGray);
 
     let mut spans = vec![
-        Span::styled(pill_label, Style::default().bg(pill_bg).fg(pill_fg).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            pill_label,
+            Style::default()
+                .bg(pill_bg)
+                .fg(pill_fg)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled(" │ ", sep),
-        Span::styled(format!("v{} ", env!("CARGO_PKG_VERSION")), Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!("v{} ", env!("CARGO_PKG_VERSION")),
+            Style::default().fg(Color::DarkGray),
+        ),
         Span::styled(" │ ", sep),
     ];
 
@@ -56,11 +68,26 @@ pub fn render_status_bar(
         spans.push(Span::styled(" │ ", sep));
     }
 
-    let wa_color = if whatsapp_connected { Color::Green } else { Color::Red };
+    let wa_color = if whatsapp_connected {
+        Color::Green
+    } else {
+        Color::Red
+    };
     spans.push(Span::styled(" ● ", Style::default().fg(wa_color)));
     spans.push(Span::styled("WA", Style::default().fg(Color::DarkGray)));
     spans.push(Span::styled(" │ ", sep));
-    spans.push(Span::styled(hints, Style::default().fg(Color::DarkGray)));
+
+    // Show copy feedback if present, otherwise show normal hints
+    if let Some(status) = copy_status {
+        spans.push(Span::styled(
+            status,
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ));
+    } else {
+        spans.push(Span::styled(hints, Style::default().fg(Color::DarkGray)));
+    }
 
     let paragraph = Paragraph::new(Line::from(spans)).style(Style::default().bg(Color::Black));
     f.render_widget(paragraph, area);


### PR DESCRIPTION
## Summary

- **`y` in Normal mode** — instantly copies the last message in the current chat to the clipboard via OSC 52
- **`v` in Normal mode** — enters a new **Message Select mode** (vim-style) where you navigate with `j`/`k`, copy with `y`/`Enter`, and cancel with `Esc`/`q`
- Selected message is highlighted with a cyan `▌` gutter and blue background
- A brief **"Copied!"** flash appears in the status bar to confirm

## Implementation

| File | Change |
|------|--------|
| `src/tui/app_state.rs` | Added `MessageSelect` to `InputMode`; `selected_message_idx: Option<usize>` on `AppState`; helper enter/exit/prev/next methods |
| `src/tui/keybindings.rs` | Added `EnterMessageSelect`, `MessageSelectPrev/Next/Copy/Exit` actions; `v` binding in Normal; `map_message_select_mode()` |
| `src/tui/widgets/message_view.rs` | `selected_message_idx` param; per-message highlight with cyan gutter + blue background |
| `src/tui/widgets/status_bar.rs` | `SELECT` mode pill (blue); hints for Select mode; Normal mode hints updated |
| `src/tui/widgets/input_bar.rs` | `MessageSelect` arm added to mode match |
| `src/tui/render.rs` | Passes `selected_message_idx` and `copy_status` to widgets |
| `src/app.rs` | Handlers for all MessageSelect actions; `copy_to_clipboard()` + `base64_encode()` using OSC 52; `copy_status` flash |

## Docs updated

- `CHANGELOG.md` — v0.3.2 release note
- `FEATURES.md` — new "Copy to Clipboard" section
- `README.md` — Normal mode table updated (`y`, `v`, `/`); new **Message Select mode** table and OSC 52 terminal compatibility note

## Terminal compatibility (OSC 52)

Works out of the box in kitty, iTerm2, WezTerm. For tmux: `set -g set-clipboard on`.