### PR TITLE
feat(media): E2EE image viewing for WhatsApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.3.3 — 2026-03-13
+
+### View images in your terminal chat
+
+WhatsApp image messages can now be opened directly from the TUI.
+
+- In **Message Select mode** (`v`), navigate to any `[Image]` message and press `Enter` (or `v` again)
+- The image is downloaded, decrypted end-to-end using the WhatsApp media key, and opened in your OS default image viewer
+- A **"Opening image..."** flash appears in the status bar while the download is in progress
+- Images without E2EE metadata (e.g. some history-sync thumbnails) fall back to a direct CDN fetch
+- Temporary files are written to `/tmp/` and cleaned up automatically on the next startup
+- A brief **"Failed to open image: …"** error is shown in the status bar if the download or viewer launch fails
+
+#### New internal pieces
+- `MediaDecryptParams` struct carries the `media_key`, `direct_path`, `file_sha256`, `file_enc_sha256`, `file_length`, and `mime_type` fields extracted from the WhatsApp image proto
+- `Provider::download_media()` trait method — `WhatsAppProvider` implements it via `download_from_params` (AES-256-CBC + HMAC, handled by the `whatsapp_rust` library)
+- `open_image_from_bytes()` in `tui/media.rs` writes bytes to a temp file with the correct extension (from MIME type or URL) and hands it to the OS viewer
+
 ## v0.3.2 — 2026-03-11
 
 ### Copy messages to clipboard

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2714,12 +2715,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -4099,6 +4102,19 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ dirs = "5"
 whatsapp-rust = { git = "https://github.com/jlucaso1/whatsapp-rust", default-features = true }
 qrcode = "0.14"
 tui-textarea = { version = "0.7", features = ["crossterm"] }
-reqwest = { version = "0.12", features = ["json"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+reqwest = { version = "0.12", features = ["json", "stream"] }
+tokio-util = { version = "0.7", features = ["rt", "io"] }
 grammers-client = { git = "https://codeberg.org/Lonami/grammers", package = "grammers-client" }
 grammers-session = { git = "https://codeberg.org/Lonami/grammers", package = "grammers-session", default-features = false, features = ["serde"] }

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,13 @@
 - Chat rename — press `r` to set custom display names (persisted across restarts)
 - Version displayed in status bar
 
+## View Images
+- Press `v` to enter **Message Select mode**, navigate to an `[Image]` message, and press `Enter` to open it
+- Images are downloaded and **end-to-end decrypted** using the WhatsApp media key — no plaintext leakage
+- Opens in your OS default image viewer (xdg-open on Linux, open on macOS)
+- Falls back to a direct CDN fetch for images that lack E2EE metadata
+- Temporary files are stored in `/tmp/` and cleaned up on next startup
+
 ## Copy to Clipboard
 - Press `y` to copy the last message in the current chat to the clipboard
 - Press `v` to enter **Message Select mode**: navigate with `j`/`k`, copy with `y` or `Enter`, cancel with `Esc`

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -1,0 +1,13 @@
+# Wishlist
+
+## Features & Improvements
+
+- [ ] **Long message display issue** - Long messages stretch out of the chat panel.
+  - Proposed fix: set a max width of 70% of the chat panel width for message bubbles.
+
+- [ ] **Bug: Username shows as `unknown` at Telegram** - User names are not resolved correctly and display as `unknown` in Telegram integration.
+
+## Completed
+
+- [x] **Show picture** - Support displaying images/pictures in chat messages. (2026-03-13)
+

--- a/docs/superpowers/plans/2026-03-13-show-picture.md
+++ b/docs/superpowers/plans/2026-03-13-show-picture.md
@@ -1,0 +1,679 @@
+# Show Picture Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Press Enter on a selected `[Image]` message to stream-download it to a temp file and open it in the OS default image viewer — zero image bytes held in Rust heap.
+
+**Architecture:** Add `Action::OpenMedia` wired to Enter in `MessageSelect` mode; a new `src/tui/media.rs` module streams the download via `reqwest` + `tokio_util::io::StreamReader` + `tokio::io::copy` straight to disk; `std::process::Command::spawn` opens the file with the OS default viewer detached. Temp files older than 24 h are cleaned up at startup.
+
+**Tech Stack:** Rust, Tokio, reqwest (stream feature), tokio-util (io feature), std::process::Command, xdg-open / open / cmd.
+
+---
+
+## Chunk 1: Dependencies, Data Layer, and media.rs
+
+### Task 1: Enable reqwest stream feature and add tokio-util io feature
+
+**Files:**
+- Modify: `Cargo.toml`
+
+**Context:**
+- `reqwest 0.12` is already present with `features = ["json"]`. We need to add `"stream"` to get `.bytes_stream()`.
+- `tokio-util 0.7` is already present with `features = ["rt"]`. We need to add `"io"` to get `StreamReader`.
+- After this change, `cargo build` must compile without errors.
+
+- [ ] **Step 1: Add features to Cargo.toml**
+
+  In `Cargo.toml`, change:
+  ```toml
+  reqwest = { version = "0.12", features = ["json"] }
+  tokio-util = { version = "0.7", features = ["rt"] }
+  ```
+  to:
+  ```toml
+  reqwest = { version = "0.12", features = ["json", "stream"] }
+  tokio-util = { version = "0.7", features = ["rt", "io"] }
+  ```
+
+- [ ] **Step 2: Verify the build compiles**
+
+  Run: `cargo build 2>&1 | tail -5`
+  Expected: `Finished` line — no errors.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add Cargo.toml Cargo.lock
+  git commit -m "chore: enable reqwest stream + tokio-util io features"
+  ```
+
+---
+
+### Task 2: Emit MessageContent::Image from WhatsApp convert
+
+**Files:**
+- Modify: `src/providers/whatsapp/convert.rs:248-255`
+
+**Context:**
+- `MessageContent::Image { url, caption }` already exists in `src/core/types.rs` but is not used.
+- The WhatsApp `image_message` protobuf has a `url` field (CDN URL) and `caption` field.
+- Currently the image arm (line 248) maps to `MessageContent::Text("[Image] ...")`. We must change it to `MessageContent::Image { url, caption }` so downstream logic can detect the URL.
+- A unit test will verify the conversion returns `MessageContent::Image` when an image URL is present, and falls back to `MessageContent::Text("[Image]")` when the URL is empty/absent.
+
+- [ ] **Step 1: Write the failing test**
+
+  Add at the bottom of `src/providers/whatsapp/convert.rs` inside `#[cfg(test)] mod tests { ... }` (create the block if absent):
+
+  ```rust
+  #[cfg(test)]
+  mod tests {
+      use super::*;
+
+      /// When image_message has a URL, extract_message_content returns Image variant.
+      #[test]
+      fn test_image_message_with_url_returns_image_content() {
+          use whatsapp_rust::waproto::whatsapp as wa;
+          let mut msg = wa::Message::default();
+          let mut img = wa::ImageMessage::default();
+          img.url = Some("https://cdn.example.com/img.jpg".to_string());
+          img.caption = Some("A caption".to_string());
+          msg.image_message = Some(img);
+          let content = extract_message_content(&msg).unwrap();
+          match content {
+              MessageContent::Image { url, caption } => {
+                  assert_eq!(url, "https://cdn.example.com/img.jpg");
+                  assert_eq!(caption, Some("A caption".to_string()));
+              }
+              other => panic!("Expected Image, got {:?}", other),
+          }
+      }
+
+      /// When image_message has no URL, fall back to Text("[Image]").
+      #[test]
+      fn test_image_message_no_url_falls_back_to_text() {
+          use whatsapp_rust::waproto::whatsapp as wa;
+          let mut msg = wa::Message::default();
+          let img = wa::ImageMessage::default(); // url = None
+          msg.image_message = Some(img);
+          let content = extract_message_content(&msg).unwrap();
+          match content {
+              MessageContent::Text(t) => assert!(t.contains("[Image]")),
+              other => panic!("Expected Text fallback, got {:?}", other),
+          }
+      }
+  }
+  ```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+  Run: `cargo test -p zero-drift-chat test_image_message 2>&1 | tail -20`
+  Expected: compile error or FAILED — `MessageContent::Image` is not returned yet.
+
+- [ ] **Step 3: Update extract_message_content to emit MessageContent::Image**
+
+  In `src/providers/whatsapp/convert.rs`, replace lines 248-255:
+
+  ```rust
+  if let Some(ref img) = base.image_message {
+      return Some(MessageContent::Text(
+          match img.caption.as_deref().filter(|s| !s.is_empty()) {
+              Some(c) => format!("[Image] {}", c),
+              None => "[Image]".to_string(),
+          },
+      ));
+  }
+  ```
+
+  with:
+
+  ```rust
+  if let Some(ref img) = base.image_message {
+      if let Some(ref url) = img.url {
+          if !url.is_empty() {
+              let caption = img.caption.clone().filter(|s| !s.is_empty());
+              return Some(MessageContent::Image {
+                  url: url.clone(),
+                  caption,
+              });
+          }
+      }
+      // Fallback: no URL available — render as text placeholder
+      return Some(MessageContent::Text(
+          match img.caption.as_deref().filter(|s| !s.is_empty()) {
+              Some(c) => format!("[Image] {}", c),
+              None => "[Image]".to_string(),
+          },
+      ));
+  }
+  ```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+  Run: `cargo test -p zero-drift-chat test_image_message 2>&1 | tail -20`
+  Expected: `test test_image_message_with_url_returns_image_content ... ok` and `test test_image_message_no_url_falls_back_to_text ... ok`.
+
+- [ ] **Step 5: Run full test suite to confirm no regressions**
+
+  Run: `cargo test 2>&1 | tail -10`
+  Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add src/providers/whatsapp/convert.rs
+  git commit -m "feat(whatsapp): emit MessageContent::Image with CDN URL"
+  ```
+
+---
+
+### Task 3: Emit MessageContent::Image from Telegram convert
+
+**Files:**
+- Modify: `src/providers/telegram/convert.rs:49-54`
+
+**Context:**
+- Currently the Telegram converter always uses `msg.text()` and falls back to `"[Media]"` — it does not distinguish image vs other media.
+- The grammers `Message` API does not expose a direct download URL in a stable public field; the correct approach is to keep the `"[Media]"` / text path for now but distinguish photos specifically: `msg.photo()` returns `Option<grammers_client::types::Photo>` which has no direct CDN URL accessible without a download round-trip.
+- **Decision (consistent with spec note "where a media URL is available"):** For Telegram, if `msg.photo().is_some()` and `msg.text().is_empty()`, emit `MessageContent::Text("[Image]")` (identical to the existing `[Media]` fallback but more specific). Full Telegram image opening requires a separate download step using the grammers client — that is **out of scope for v1**. We add the distinction now so the code is consistent and the TODO is visible.
+- A unit test verifies the chat-id round-trip (already exists). No new grammers-type unit tests are possible (private constructors).
+
+- [ ] **Step 1: Update grammers_message_to_unified to distinguish photos**
+
+  In `src/providers/telegram/convert.rs`, replace lines 49-54:
+
+  ```rust
+  // Text content — media becomes "[Media]" placeholder (v1)
+  let text = if msg.text().is_empty() {
+      "[Media]".to_string()
+  } else {
+      msg.text().to_string()
+  };
+  ```
+
+  with:
+
+  ```rust
+  // Text content — distinguish photo vs other media (v1: no URL download yet)
+  let content = if !msg.text().is_empty() {
+      MessageContent::Text(msg.text().to_string())
+  } else if msg.photo().is_some() {
+      // TODO(show-picture): Telegram photo download requires grammers client.
+      // For now render as [Image] text. A future iteration can add a proper
+      // download path via the grammers client handle.
+      MessageContent::Text("[Image]".to_string())
+  } else {
+      MessageContent::Text("[Media]".to_string())
+  };
+  ```
+
+  Then update the `UnifiedMessage` struct literal to use `content` instead of `MessageContent::Text(text)`:
+
+  Replace:
+  ```rust
+  content: MessageContent::Text(text),
+  ```
+  with:
+  ```rust
+  content,
+  ```
+
+  And remove the now-unused `let text = ...` binding (it is replaced by the `content` binding above).
+
+- [ ] **Step 2: Build to confirm it compiles**
+
+  Run: `cargo build 2>&1 | tail -5`
+  Expected: `Finished` — no errors.
+
+- [ ] **Step 3: Run full test suite**
+
+  Run: `cargo test 2>&1 | tail -10`
+  Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add src/providers/telegram/convert.rs
+  git commit -m "feat(telegram): distinguish photo vs other media in converter"
+  ```
+
+---
+
+### Task 4: Create src/tui/media.rs with open_image and cleanup_temp_images
+
+**Files:**
+- Create: `src/tui/media.rs`
+- Modify: `src/tui/mod.rs`
+
+**Context:**
+- `open_image(url)` must never hold full image bytes in the Rust heap. The streaming pipeline is: `reqwest` response bytes_stream → `tokio_util::io::StreamReader` → `tokio::io::copy` → `tokio::fs::File`. The read buffer inside `copy` is ~8 KB — that is the maximum in-memory footprint.
+- The temp file path is `/tmp/zero-drift-<hash>.jpg`. The hash is computed from the URL using `std::collections::hash_map::DefaultHasher` — no extra allocations.
+- The OS opener is selected at compile time via `cfg`:
+  - Linux: `xdg-open`
+  - macOS: `open`
+  - Windows: `cmd /c start "" "<path>"`
+- `cleanup_temp_images()` is a synchronous function (uses `std::fs`) that deletes `/tmp/zero-drift-*` files older than 24 hours. It is called once at startup inside `tokio::task::spawn_blocking`.
+- Both functions silently ignore all errors (log via `tracing::error!`/`tracing::warn!`).
+- `futures = "0.3"` is already in `Cargo.toml` (line 22); `TryStreamExt` from it is used inside `media.rs` — no new crate needed.
+- Note: `temp_path_for_url` always appends `.jpg` — a known v1 simplification. Non-JPEG images will still be written correctly (the extension is cosmetic); `cleanup_temp_images` matches on the `zero-drift-` prefix rather than extension so cleanup still works.
+
+- [ ] **Step 1: Write failing unit test for temp_path_for_url**
+
+  Create `src/tui/media.rs` with the test only first:
+
+  ```rust
+  #[cfg(test)]
+  mod tests {
+      use super::temp_path_for_url;
+
+      #[test]
+      fn test_temp_path_same_url_gives_same_path() {
+          let a = temp_path_for_url("https://cdn.example.com/img.jpg");
+          let b = temp_path_for_url("https://cdn.example.com/img.jpg");
+          assert_eq!(a, b);
+      }
+
+      #[test]
+      fn test_temp_path_different_urls_give_different_paths() {
+          let a = temp_path_for_url("https://cdn.example.com/img1.jpg");
+          let b = temp_path_for_url("https://cdn.example.com/img2.jpg");
+          assert_ne!(a, b);
+      }
+
+      #[test]
+      fn test_temp_path_starts_with_tmp_prefix() {
+          let p = temp_path_for_url("https://cdn.example.com/img.jpg");
+          let s = p.to_string_lossy();
+          assert!(s.contains("zero-drift-"), "path should contain zero-drift-: {}", s);
+          assert!(s.ends_with(".jpg"), "path should end with .jpg: {}", s);
+      }
+  }
+  ```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+  Run: `cargo test -p zero-drift-chat test_temp_path 2>&1 | tail -10`
+  Expected: compile error — `temp_path_for_url` does not exist yet.
+
+- [ ] **Step 3: Implement the full media.rs module**
+
+  Replace `src/tui/media.rs` with the full implementation:
+
+  ```rust
+  use std::hash::{Hash, Hasher};
+  use std::collections::hash_map::DefaultHasher;
+  use std::path::PathBuf;
+  use std::time::{Duration, SystemTime};
+
+  use futures::TryStreamExt;
+  use tokio_util::io::StreamReader;
+
+  /// Generate a deterministic temp file path for a given image URL.
+  /// Pattern: /tmp/zero-drift-<u64_hash>.jpg
+  pub fn temp_path_for_url(url: &str) -> PathBuf {
+      let mut hasher = DefaultHasher::new();
+      url.hash(&mut hasher);
+      let hash = hasher.finish();
+      std::env::temp_dir().join(format!("zero-drift-{}.jpg", hash))
+  }
+
+  /// Stream-download `url` to a temp file and open it with the OS default viewer.
+  ///
+  /// Image bytes flow: network → kernel buffer → disk.
+  /// The Rust heap holds only the ~8 KB read buffer inside `tokio::io::copy` —
+  /// never the full image.
+  pub async fn open_image(url: String) -> anyhow::Result<()> {
+      let path = temp_path_for_url(&url);
+
+      // Download only if not already cached
+      if !path.exists() {
+          let response = reqwest::get(&url).await?;
+          let byte_stream = response
+              .bytes_stream()
+              .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
+          let mut reader = StreamReader::new(byte_stream);
+          let mut file = tokio::fs::File::create(&path).await?;
+          tokio::io::copy(&mut reader, &mut file).await?;
+      }
+
+      spawn_os_opener(&path);
+      Ok(())
+  }
+
+  /// Spawn the OS default image viewer for `path`. Fire-and-forget.
+  fn spawn_os_opener(path: &PathBuf) {
+      #[cfg(target_os = "linux")]
+      let result = std::process::Command::new("xdg-open").arg(path).spawn();
+
+      #[cfg(target_os = "macos")]
+      let result = std::process::Command::new("open").arg(path).spawn();
+
+      #[cfg(target_os = "windows")]
+      let result = std::process::Command::new("cmd")
+          .args(["/c", "start", "", &path.to_string_lossy()])
+          .spawn();
+
+      #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+      let result: std::io::Result<std::process::Child> =
+          Err(std::io::Error::new(std::io::ErrorKind::Unsupported, "unsupported OS"));
+
+      if let Err(e) = result {
+          tracing::error!("Failed to spawn OS opener for {:?}: {}", path, e);
+      }
+  }
+
+  /// Delete `/tmp/zero-drift-*` files older than 24 hours.
+  /// Best-effort: all errors are silently logged.
+  pub fn cleanup_temp_images() {
+      let cutoff = match SystemTime::now().checked_sub(Duration::from_secs(24 * 3600)) {
+          Some(t) => t,
+          None => return,
+      };
+
+      let tmp = std::env::temp_dir();
+      let entries = match std::fs::read_dir(&tmp) {
+          Ok(e) => e,
+          Err(e) => {
+              tracing::warn!("cleanup_temp_images: cannot read {:?}: {}", tmp, e);
+              return;
+          }
+      };
+
+      for entry in entries.flatten() {
+          let name = entry.file_name();
+          let name_str = name.to_string_lossy();
+          if !name_str.starts_with("zero-drift-") {
+              continue;
+          }
+          let path = entry.path();
+          let mtime = match entry.metadata().and_then(|m| m.modified()) {
+              Ok(t) => t,
+              Err(_) => continue,
+          };
+          if mtime < cutoff {
+              if let Err(e) = std::fs::remove_file(&path) {
+                  tracing::warn!("cleanup_temp_images: failed to remove {:?}: {}", path, e);
+              }
+          }
+      }
+  }
+
+  #[cfg(test)]
+  mod tests {
+      use super::temp_path_for_url;
+
+      #[test]
+      fn test_temp_path_same_url_gives_same_path() {
+          let a = temp_path_for_url("https://cdn.example.com/img.jpg");
+          let b = temp_path_for_url("https://cdn.example.com/img.jpg");
+          assert_eq!(a, b);
+      }
+
+      #[test]
+      fn test_temp_path_different_urls_give_different_paths() {
+          let a = temp_path_for_url("https://cdn.example.com/img1.jpg");
+          let b = temp_path_for_url("https://cdn.example.com/img2.jpg");
+          assert_ne!(a, b);
+      }
+
+      #[test]
+      fn test_temp_path_starts_with_tmp_prefix() {
+          let p = temp_path_for_url("https://cdn.example.com/img.jpg");
+          let s = p.to_string_lossy();
+          assert!(s.contains("zero-drift-"), "path should contain zero-drift-: {}", s);
+          assert!(s.ends_with(".jpg"), "path should end with .jpg: {}", s);
+      }
+  }
+  ```
+
+- [ ] **Step 4: Declare the module in src/tui/mod.rs**
+
+  Add `pub mod media;` to `src/tui/mod.rs`. The file becomes:
+
+  ```rust
+  pub mod app_state;
+  pub mod search;
+  pub mod event;
+  pub mod keybindings;
+  pub mod media;
+  pub mod osc8;
+  pub mod render;
+  pub mod time_parse;
+  pub mod widgets;
+  ```
+
+- [ ] **Step 5: Run tests to confirm temp_path tests pass**
+
+  Run: `cargo test -p zero-drift-chat test_temp_path 2>&1 | tail -10`
+  Expected: all 3 tests pass.
+
+- [ ] **Step 6: Run full build and test suite**
+
+  Run: `cargo test 2>&1 | tail -10`
+  Expected: all tests pass — no compile errors.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add src/tui/media.rs src/tui/mod.rs
+  git commit -m "feat(tui): add media.rs with open_image and cleanup_temp_images"
+  ```
+
+---
+
+## Chunk 2: Action Wiring and Startup Cleanup
+
+### Task 5: Add Action::OpenMedia to keybindings
+
+**Files:**
+- Modify: `src/tui/keybindings.rs`
+
+**Context:**
+- `Action::OpenMedia` must be added to the `Action` enum.
+- In `map_message_select_mode`, the current binding is:
+  ```rust
+  KeyCode::Char('y') | KeyCode::Enter => Action::MessageSelectCopy,
+  ```
+  Enter should now trigger `Action::OpenMedia`, not `Action::MessageSelectCopy`.
+  `y` alone should still trigger `Action::MessageSelectCopy`.
+- A unit test verifies:
+  1. Enter in MessageSelect mode → `Action::OpenMedia`
+  2. `y` in MessageSelect mode → `Action::MessageSelectCopy`
+  3. Esc in MessageSelect mode → `Action::MessageSelectExit`
+
+- [ ] **Step 1: Write the failing tests**
+
+  Add inside `src/tui/keybindings.rs` (create `#[cfg(test)] mod tests` if absent):
+
+  ```rust
+  #[cfg(test)]
+  mod tests {
+      use super::*;
+      use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+      fn key(code: KeyCode) -> KeyEvent {
+          KeyEvent::new(code, KeyModifiers::NONE)
+      }
+
+      #[test]
+      fn enter_in_message_select_maps_to_open_media() {
+          let action = map_key(key(KeyCode::Enter), InputMode::MessageSelect, true);
+          assert_eq!(action, Action::OpenMedia);
+      }
+
+      #[test]
+      fn y_in_message_select_maps_to_copy() {
+          let action = map_key(key(KeyCode::Char('y')), InputMode::MessageSelect, true);
+          assert_eq!(action, Action::MessageSelectCopy);
+      }
+
+      #[test]
+      fn esc_in_message_select_maps_to_exit() {
+          let action = map_key(key(KeyCode::Esc), InputMode::MessageSelect, true);
+          assert_eq!(action, Action::MessageSelectExit);
+      }
+  }
+  ```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+  Run: `cargo test -p zero-drift-chat enter_in_message_select 2>&1 | tail -10`
+  Expected: compile error — `Action::OpenMedia` does not exist yet.
+
+- [ ] **Step 3: Add Action::OpenMedia to the enum**
+
+  In `src/tui/keybindings.rs`, add `OpenMedia` to the `Action` enum **after `MessageSelectExit` and before `None`** (the `None` arm must remain last):
+
+  ```rust
+  MessageSelectExit,  // Esc — exit without copying
+  OpenMedia,          // Enter — open image in OS viewer
+  ScheduleMessage,    // ... (existing lines continue)
+  ```
+
+  The resulting order is: `...MessageSelectExit`, `OpenMedia`, then the existing `ScheduleMessage` / ... / `None` arms unchanged.
+
+- [ ] **Step 4: Update map_message_select_mode**
+
+  Change:
+  ```rust
+  KeyCode::Char('y') | KeyCode::Enter => Action::MessageSelectCopy,
+  ```
+  to:
+  ```rust
+  KeyCode::Char('y') => Action::MessageSelectCopy,
+  KeyCode::Enter => Action::OpenMedia,
+  ```
+
+- [ ] **Step 5: Run the keybinding tests**
+
+  Run: `cargo test -p zero-drift-chat enter_in_message_select 2>&1 | tail -10`
+  Run: `cargo test -p zero-drift-chat y_in_message_select 2>&1 | tail -10`
+  Run: `cargo test -p zero-drift-chat esc_in_message_select 2>&1 | tail -10`
+  Expected: all 3 pass.
+
+- [ ] **Step 6: Run full test suite**
+
+  Run: `cargo test 2>&1 | tail -10`
+  Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add src/tui/keybindings.rs
+  git commit -m "feat(keybindings): add Action::OpenMedia, bind Enter in MessageSelect"
+  ```
+
+---
+
+### Task 6: Handle Action::OpenMedia in app.rs + spawn startup cleanup
+
+**Files:**
+- Modify: `src/app.rs`
+
+**Context:**
+- `handle_action` needs a new arm for `Action::OpenMedia`.
+- The logic (from spec):
+  1. Read `self.state.selected_message_idx`.
+  2. If the message at that index has `MessageContent::Image { url, .. }`, clone the URL.
+  3. `tokio::spawn` an async block calling `tui::media::open_image(url).await`.
+  4. Set `self.state.copy_status = Some("Opening image...".to_string())` for status bar feedback.
+  5. Call `self.state.exit_message_select()`.
+  6. If the message is NOT an image (e.g., it's text), do nothing except exit message select (do not show any error).
+- `startup cleanup`: In `App::run()`, after `self.router.start_all().await?` (around line 152), add:
+  ```rust
+  tokio::task::spawn_blocking(crate::tui::media::cleanup_temp_images);
+  ```
+- The `Action::None` arm remains the last arm to avoid compiler warnings.
+- A unit test for handle_action is not practical (App is not easily unit-testable — it holds providers, DB, terminal). The integration is verified by running the app and pressing Enter on an `[Image]` message. Manual test steps are described at the end of this task.
+
+- [ ] **Step 1: Add the OpenMedia import — verify media module is accessible**
+
+  In `src/app.rs`, confirm `use crate::tui;` is already present (it is, at line 32). No new import is needed — `crate::tui::media::open_image` is accessible via that path.
+
+- [ ] **Step 2: Add Action::OpenMedia arm in handle_action**
+
+  In `src/app.rs`, inside `handle_action`, add the following arm **before** `Action::None => {}`:
+
+  ```rust
+  Action::OpenMedia => {
+      if let Some(idx) = self.state.selected_message_idx {
+          if let Some(msg) = self.state.messages.get(idx) {
+              if let MessageContent::Image { url, .. } = &msg.content {
+                  let url = url.clone();
+                  tokio::spawn(async move {
+                      if let Err(e) = crate::tui::media::open_image(url).await {
+                          tracing::error!("Failed to open image: {}", e);
+                      }
+                  });
+                  self.state.copy_status = Some("Opening image...".to_string());
+              }
+          }
+      }
+      self.state.exit_message_select();
+  }
+  ```
+
+- [ ] **Step 3: Spawn cleanup task at startup**
+
+  In `src/app.rs`, in `App::run()`, after `self.router.start_all().await?;` (line 152), add:
+
+  ```rust
+  tokio::task::spawn_blocking(crate::tui::media::cleanup_temp_images);
+  ```
+
+- [ ] **Step 4: Build to confirm it compiles**
+
+  Run: `cargo build 2>&1 | tail -5`
+  Expected: `Finished` — no warnings about unused match arms, no errors.
+
+- [ ] **Step 5: Run full test suite**
+
+  Run: `cargo test 2>&1 | tail -10`
+  Expected: all tests pass.
+
+- [ ] **Step 6: Manual integration smoke test**
+
+  To verify end-to-end:
+  1. Run the app with `cargo run`.
+  2. If using the Mock provider: mock messages are text-only, so no `[Image]` messages will appear naturally. You can temporarily patch `src/providers/mock/mod.rs` to emit a `MessageContent::Image { url: "https://...", caption: None }` message, or test with a real WhatsApp account that has received an image.
+  3. Navigate to a chat with an `[Image]` message.
+  4. Press `v` to enter MessageSelect mode.
+  5. Navigate to the `[Image]` message with `j`/`k`.
+  6. Press Enter.
+  7. Expected: status bar briefly shows `"Opening image..."`, the image opens in the OS viewer, MessageSelect mode exits.
+  8. Press `v`, navigate to a text message, press Enter — expected: MessageSelect exits silently (no image opened, no error shown).
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add src/app.rs
+  git commit -m "feat(app): handle Action::OpenMedia, spawn startup cleanup"
+  ```
+
+---
+
+### Task 7: Update WISHLIST.md to mark item #1 complete
+
+**Files:**
+- Modify: `docs/WISHLIST.md`
+
+**Context:**
+- The wishlist item `[ ] #1 — Show picture` should be checked off and moved to the Completed section.
+
+- [ ] **Step 1: Mark item #1 complete in WISHLIST.md**
+
+  In `docs/WISHLIST.md`, change:
+  ```
+  - [ ] **Show picture** - Support displaying images/pictures in chat messages.
+  ```
+  to (remove from the Features list and add to Completed):
+  ```
+  - [x] **Show picture** - Support displaying images/pictures in chat messages. (2026-03-13)
+  ```
+  Move that line into the `## Completed` section at the bottom of the file.
+
+- [ ] **Step 2: Commit**
+
+  ```bash
+  git add docs/WISHLIST.md
+  git commit -m "docs: mark wishlist #1 show-picture as complete"
+  ```

--- a/docs/superpowers/specs/2026-03-13-show-picture-design.md
+++ b/docs/superpowers/specs/2026-03-13-show-picture-design.md
@@ -1,0 +1,140 @@
+# Design: Show Picture — Open Image with Default OS App
+
+**Date:** 2026-03-13  
+**Status:** Approved  
+**Wishlist item:** #1 — Show picture
+
+---
+
+## Goal
+
+When a message contains an image (`[Image]` placeholder), the user can press Enter while the message is selected to download and open it in the OS default image viewer — without loading image bytes into the Rust process heap.
+
+---
+
+## Constraints
+
+- Zero image bytes held in the Rust process memory at any time.
+- Works on Linux, macOS, and Windows (the three supported platforms).
+- No new UI overlays or modes required.
+- Fits the existing `MessageSelect` mode UX pattern.
+
+---
+
+## Design
+
+### 1. Data Layer — Use `MessageContent::Image` Properly
+
+**Files:** `src/core/types.rs`, `src/providers/whatsapp/convert.rs`, `src/providers/telegram/convert.rs`
+
+`MessageContent::Image { url, caption }` already exists in the type system but is unused — both providers currently downcast images to `MessageContent::Text("[Image] ...")`.
+
+**Change:** Update `extract_message_content` in `whatsapp/convert.rs` to emit `MessageContent::Image { url, caption }` using the CDN URL already present in the WhatsApp protobuf (`img.url`). Apply the same change to Telegram's `convert.rs` where a media URL is available.
+
+`MessageContent::as_text()` already returns `"[Image]"` / caption as a fallback — no change needed there. The rendered `[Image]` label in the TUI remains unchanged.
+
+### 2. New Module — `src/tui/media.rs`
+
+Single public async function:
+
+```rust
+pub async fn open_image(url: String) -> anyhow::Result<()>
+```
+
+**Steps:**
+
+1. **Generate temp path** — `/tmp/zero-drift-<hash>.jpg` where `<hash>` is a short deterministic hash of the URL (using `std::collections::hash_map::DefaultHasher` — no allocation for image bytes).
+
+2. **Stream download** — `reqwest::get(&url).await` returns a streaming response. Use `.bytes_stream()` piped through `tokio_util::io::StreamReader` into `tokio::io::copy` writing to a `tokio::fs::File`. Image bytes flow: network → kernel buffer → disk. The Rust heap holds only a small read buffer (~8 KB), never the full image.
+
+3. **Spawn OS opener** (detached, fire-and-forget):
+   - Linux: `xdg-open <path>`
+   - macOS: `open <path>`
+   - Windows: `cmd /c start "" "<path>"`
+   - Selected at compile time via `#[cfg(target_os = "...")]`.
+   - `std::process::Command::new(opener).arg(&path).spawn()` — not awaited.
+
+4. Return `Ok(())`.
+
+**Error handling:** If download or open fails, log the error via `tracing::error!`. No panic. Status bar will not show an error (keep it simple for v1).
+
+### 3. Temp File Cleanup — `cleanup_temp_images()`
+
+A best-effort function called once at app startup (non-blocking, spawned as a `tokio::task`):
+
+```rust
+fn cleanup_temp_images() {
+    // Glob /tmp/zero-drift-*.{jpg,png,gif,webp}
+    // Delete files older than 24 hours
+    // Silently ignore all errors
+}
+```
+
+Uses `std::fs::read_dir("/tmp")` + metadata mtime comparison. No extra dependencies.
+
+### 4. Action Wiring
+
+**`src/tui/keybindings.rs`**
+
+Add `Action::OpenMedia` to the `Action` enum.
+
+Map `Enter` in `InputMode::MessageSelect` → `Action::OpenMedia`.
+
+> Currently `Enter` has no binding in `MessageSelect` mode. `y` is `MessageSelectCopy`, `Esc`/`q` is `MessageSelectExit`.
+
+**`src/app.rs` — `handle_action`**
+
+```rust
+Action::OpenMedia => {
+    if let Some(idx) = self.state.selected_message_idx {
+        if let Some(msg) = self.state.messages.get(idx) {
+            if let MessageContent::Image { url, .. } = &msg.content {
+                let url = url.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = media::open_image(url).await {
+                        tracing::error!("Failed to open image: {}", e);
+                    }
+                });
+                self.state.copy_status = Some("Opening image...".to_string());
+            }
+        }
+    }
+    self.state.exit_message_select();
+}
+```
+
+### 5. Status Feedback
+
+Reuses the existing `copy_status` flash mechanism in the status bar. `"Opening image..."` appears for ~1 tick (~250 ms) then clears automatically — consistent with the `"Copied!"` feedback pattern.
+
+---
+
+## Dependencies
+
+- `reqwest` — already in `Cargo.toml` (used by AI providers). Add `stream` feature if not already enabled.
+- `tokio-util` — add to `Cargo.toml` with `io` feature, for `StreamReader`.
+- No other new dependencies.
+
+---
+
+## Out of Scope
+
+- Video/audio/document open (can follow the same pattern later).
+- Progress indicator while downloading.
+- Caching already-downloaded images (temp file reuse by hash covers the common case).
+- Error feedback in the status bar for failed downloads (tracing log only for v1).
+
+---
+
+## File Touch List
+
+| File | Change |
+|---|---|
+| `src/core/types.rs` | No change needed |
+| `src/providers/whatsapp/convert.rs` | Emit `MessageContent::Image { url, caption }` |
+| `src/providers/telegram/convert.rs` | Emit `MessageContent::Image { url, caption }` where available |
+| `src/tui/media.rs` | New — `open_image()` + `cleanup_temp_images()` |
+| `src/tui/mod.rs` | Declare `pub mod media` |
+| `src/tui/keybindings.rs` | Add `Action::OpenMedia`, map Enter in MessageSelect |
+| `src/app.rs` | Handle `Action::OpenMedia`, spawn cleanup task at startup |
+| `Cargo.toml` | Add `tokio-util` with `io` feature; ensure `reqwest/stream` |

--- a/src/app.rs
+++ b/src/app.rs
@@ -922,6 +922,9 @@ impl App {
             Action::MessageSelectExit => {
                 self.state.exit_message_select();
             }
+            Action::OpenMedia => {
+                // TODO(Task 6): open media attachment for the selected message
+            }
             // Schedule actions
             Action::ScheduleMessage => {
                 let input = self.state.take_input();

--- a/src/app.rs
+++ b/src/app.rs
@@ -932,56 +932,66 @@ impl App {
             Action::OpenMedia => {
                 if let Some(idx) = self.state.selected_message_idx {
                     if let Some(msg) = self.state.messages.get(idx) {
-                        if let MessageContent::Image { url, decrypt_params, .. } = &msg.content {
-                            let url = url.clone();
-                            let platform = msg.platform;
+                        match &msg.content {
+                            MessageContent::Image { url, decrypt_params, .. } => {
+                                let url = url.clone();
+                                let platform = msg.platform;
 
-                            if let Some(params) = decrypt_params.clone() {
-                                // E2EE path: download + decrypt via provider, then open
-                                if let Some(provider) = self.router.get_provider_mut(platform) {
-                                    match provider.download_media(&params).await {
-                                        Ok(bytes) => {
-                                            let cache_key = params.direct_path.clone();
-                                            let mime = params.mime_type.clone();
-                                            let err_tx = self.event_tx.clone();
-                                            tokio::spawn(async move {
-                                                if let Err(e) = crate::tui::media::open_image_from_bytes(
-                                                    bytes,
-                                                    &cache_key,
-                                                    mime.as_deref(),
-                                                )
-                                                .await
-                                                {
-                                                    tracing::error!("Failed to open image: {}", e);
-                                                    let _ = err_tx.send(AppEvent::MediaError(
-                                                        format!("Failed to open image: {}", e),
-                                                    ));
-                                                }
-                                            });
-                                            self.state.copy_status = Some("Opening image...".to_string());
+                                if let Some(params) = decrypt_params.clone() {
+                                    // E2EE path: download + decrypt via provider, then open
+                                    if let Some(provider) = self.router.get_provider_mut(platform) {
+                                        match provider.download_media(&params).await {
+                                            Ok(bytes) => {
+                                                let cache_key = params.direct_path.clone();
+                                                let mime = params.mime_type.clone();
+                                                let err_tx = self.event_tx.clone();
+                                                tokio::spawn(async move {
+                                                    if let Err(e) = crate::tui::media::open_image_from_bytes(
+                                                        bytes,
+                                                        &cache_key,
+                                                        mime.as_deref(),
+                                                    )
+                                                    .await
+                                                    {
+                                                        tracing::error!("Failed to open image: {}", e);
+                                                        let _ = err_tx.send(AppEvent::MediaError(
+                                                            format!("Failed to open image: {}", e),
+                                                        ));
+                                                    }
+                                                });
+                                                self.state.copy_status = Some("Opening image...".to_string());
+                                            }
+                                            Err(e) => {
+                                                tracing::error!("Failed to download media: {}", e);
+                                                self.state.copy_status = Some(format!("Failed to download image: {}", e));
+                                            }
                                         }
-                                        Err(e) => {
-                                            tracing::error!("Failed to download media: {}", e);
-                                            self.state.copy_status = Some(format!("Failed to download image: {}", e));
-                                        }
+                                    } else {
+                                        tracing::error!("No provider found for platform {:?}", platform);
+                                        self.state.copy_status = Some("No provider for this message".to_string());
                                     }
                                 } else {
-                                    tracing::error!("No provider found for platform {:?}", platform);
-                                    self.state.copy_status = Some("No provider for this message".to_string());
+                                    // Plaintext CDN path (non-E2EE providers)
+                                    let err_tx = self.event_tx.clone();
+                                    tokio::spawn(async move {
+                                        if let Err(e) = crate::tui::media::open_image(url).await {
+                                            tracing::error!("Failed to open image: {}", e);
+                                            let _ = err_tx.send(AppEvent::MediaError(
+                                                format!("Failed to open image: {}", e),
+                                            ));
+                                        }
+                                    });
+                                    self.state.copy_status = Some("Opening image...".to_string());
                                 }
-                            } else {
-                                // Plaintext CDN path (non-E2EE providers)
-                                let err_tx = self.event_tx.clone();
-                                tokio::spawn(async move {
-                                    if let Err(e) = crate::tui::media::open_image(url).await {
-                                        tracing::error!("Failed to open image: {}", e);
-                                        let _ = err_tx.send(AppEvent::MediaError(
-                                            format!("Failed to open image: {}", e),
-                                        ));
-                                    }
-                                });
-                                self.state.copy_status = Some("Opening image...".to_string());
                             }
+                            MessageContent::Text(t) if t.contains("[Image]") => {
+                                // Old history-sync messages stored as Text("[Image]") before
+                                // image viewing support was added — no download URL available.
+                                self.state.copy_status = Some(
+                                    "Image not available — received before image viewing was supported".to_string(),
+                                );
+                            }
+                            _ => {}
                         }
                     }
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -150,6 +150,7 @@ impl App {
 
         // Start all providers
         self.router.start_all().await?;
+        tokio::task::spawn_blocking(crate::tui::media::cleanup_temp_images);
 
         // Track which providers are enabled for status bar
         self.state.mock_enabled = self.config.mock_provider.enabled;
@@ -923,7 +924,20 @@ impl App {
                 self.state.exit_message_select();
             }
             Action::OpenMedia => {
-                // TODO(Task 6): open media attachment for the selected message
+                if let Some(idx) = self.state.selected_message_idx {
+                    if let Some(msg) = self.state.messages.get(idx) {
+                        if let MessageContent::Image { url, .. } = &msg.content {
+                            let url = url.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = crate::tui::media::open_image(url).await {
+                                    tracing::error!("Failed to open image: {}", e);
+                                }
+                            });
+                            self.state.copy_status = Some("Opening image...".to_string());
+                        }
+                    }
+                }
+                self.state.exit_message_select();
             }
             // Schedule actions
             Action::ScheduleMessage => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -971,17 +971,12 @@ impl App {
                                         self.state.copy_status = Some("No provider for this message".to_string());
                                     }
                                 } else {
-                                    // Plaintext CDN path (non-E2EE providers)
-                                    let err_tx = self.event_tx.clone();
-                                    tokio::spawn(async move {
-                                        if let Err(e) = crate::tui::media::open_image(url).await {
-                                            tracing::error!("Failed to open image: {}", e);
-                                            let _ = err_tx.send(AppEvent::MediaError(
-                                                format!("Failed to open image: {}", e),
-                                            ));
-                                        }
-                                    });
-                                    self.state.copy_status = Some("Opening image...".to_string());
+                                    // No decrypt params — the image is E2EE encrypted on the CDN
+                                    // but the decryption keys were not captured when this message
+                                    // was received (e.g. older messages synced from history).
+                                    self.state.copy_status = Some(
+                                        "Image cannot be opened — decryption keys unavailable (message received before key capture was supported)".to_string(),
+                                    );
                                 }
                             }
                             MessageContent::Text(t) if t.contains("[Image]") => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -44,6 +44,7 @@ pub struct App {
     db_summary_rx: tokio::sync::mpsc::UnboundedReceiver<(String, String)>,
     schedule_status_ticks: u8,
     telegram_auth_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::providers::telegram::AuthInput>>,
+    event_tx: tokio::sync::mpsc::UnboundedSender<AppEvent>,
 }
 
 impl App {
@@ -69,7 +70,7 @@ impl App {
                 _           => Box::new(OpenAiClient::new(config.ai.base_url.clone(), config.ai.api_key.clone())),
             };
             tracing::info!("AI worker created — autocomplete enabled");
-            Some(AiWorker::new(provider, config.ai.clone(), event_tx))
+            Some(AiWorker::new(provider, config.ai.clone(), event_tx.clone()))
         } else {
             tracing::info!("AI worker NOT created — ai.enabled = false in config");
             None
@@ -93,6 +94,7 @@ impl App {
             db_summary_rx,
             schedule_status_ticks: 0,
             telegram_auth_tx: None,
+            event_tx,
         }
     }
 
@@ -307,6 +309,10 @@ impl App {
                     tracing::info!(error = %e, "AI autocomplete error");
                     self.state.push_ai_log(format!("[error] ← {}", e));
                     self.state.ai_status = Some(format!("AI: {}", e));
+                }
+                Some(AppEvent::MediaError(e)) => {
+                    tracing::error!(error = %e, "Media open error");
+                    self.state.copy_status = Some(e);
                 }
                 Some(AppEvent::Quit) | None => {
                     break;
@@ -926,14 +932,56 @@ impl App {
             Action::OpenMedia => {
                 if let Some(idx) = self.state.selected_message_idx {
                     if let Some(msg) = self.state.messages.get(idx) {
-                        if let MessageContent::Image { url, .. } = &msg.content {
+                        if let MessageContent::Image { url, decrypt_params, .. } = &msg.content {
                             let url = url.clone();
-                            tokio::spawn(async move {
-                                if let Err(e) = crate::tui::media::open_image(url).await {
-                                    tracing::error!("Failed to open image: {}", e);
+                            let platform = msg.platform;
+
+                            if let Some(params) = decrypt_params.clone() {
+                                // E2EE path: download + decrypt via provider, then open
+                                if let Some(provider) = self.router.get_provider_mut(platform) {
+                                    match provider.download_media(&params).await {
+                                        Ok(bytes) => {
+                                            let cache_key = params.direct_path.clone();
+                                            let mime = params.mime_type.clone();
+                                            let err_tx = self.event_tx.clone();
+                                            tokio::spawn(async move {
+                                                if let Err(e) = crate::tui::media::open_image_from_bytes(
+                                                    bytes,
+                                                    &cache_key,
+                                                    mime.as_deref(),
+                                                )
+                                                .await
+                                                {
+                                                    tracing::error!("Failed to open image: {}", e);
+                                                    let _ = err_tx.send(AppEvent::MediaError(
+                                                        format!("Failed to open image: {}", e),
+                                                    ));
+                                                }
+                                            });
+                                            self.state.copy_status = Some("Opening image...".to_string());
+                                        }
+                                        Err(e) => {
+                                            tracing::error!("Failed to download media: {}", e);
+                                            self.state.copy_status = Some(format!("Failed to download image: {}", e));
+                                        }
+                                    }
+                                } else {
+                                    tracing::error!("No provider found for platform {:?}", platform);
+                                    self.state.copy_status = Some("No provider for this message".to_string());
                                 }
-                            });
-                            self.state.copy_status = Some("Opening image...".to_string());
+                            } else {
+                                // Plaintext CDN path (non-E2EE providers)
+                                let err_tx = self.event_tx.clone();
+                                tokio::spawn(async move {
+                                    if let Err(e) = crate::tui::media::open_image(url).await {
+                                        tracing::error!("Failed to open image: {}", e);
+                                        let _ = err_tx.send(AppEvent::MediaError(
+                                            format!("Failed to open image: {}", e),
+                                        ));
+                                    }
+                                });
+                                self.state.copy_status = Some("Opening image...".to_string());
+                            }
                         }
                     }
                 }

--- a/src/core/provider.rs
+++ b/src/core/provider.rs
@@ -4,6 +4,9 @@ use tokio::sync::mpsc;
 use super::error::Result;
 use super::types::*;
 
+/// Opaque bytes of a downloaded + decrypted media file.
+pub type MediaBytes = Vec<u8>;
+
 #[derive(Debug, Clone)]
 pub enum ProviderEvent {
     NewMessage(UnifiedMessage),
@@ -36,6 +39,14 @@ pub trait MessagingProvider: Send + Sync {
     async fn get_messages(&self, chat_id: &str) -> Result<Vec<UnifiedMessage>>;
     async fn mark_as_read(&self, _chat_id: &str, _msg_ids: Vec<String>) -> Result<()> {
         Ok(())
+    }
+    /// Download and decrypt a media file identified by `params`.
+    ///
+    /// Returns the raw plaintext bytes of the media.
+    /// The default implementation returns an error; providers that serve E2EE
+    /// media (e.g. WhatsApp) must override this.
+    async fn download_media(&self, _params: &MediaDecryptParams) -> Result<MediaBytes> {
+        Err(anyhow::anyhow!("download_media not supported by this provider"))
     }
     fn name(&self) -> &str;
     fn platform(&self) -> Platform;

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -30,12 +30,34 @@ pub enum MessageStatus {
     Failed,
 }
 
+/// Provider-specific parameters needed to download and decrypt E2EE media.
+/// Currently only WhatsApp requires this; other providers serve plaintext CDN URLs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MediaDecryptParams {
+    /// HKDF-derived AES-256-CBC key material.
+    pub media_key: Vec<u8>,
+    /// CDN path component used to construct the authenticated download URL.
+    pub direct_path: String,
+    /// SHA-256 of the plaintext file (for integrity verification after decryption).
+    pub file_sha256: Vec<u8>,
+    /// SHA-256 of the encrypted blob.
+    pub file_enc_sha256: Vec<u8>,
+    /// Length of the plaintext file in bytes.
+    pub file_length: u64,
+    /// MIME type reported by the provider (e.g. "image/jpeg").
+    pub mime_type: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MessageContent {
     Text(String),
     Image {
         url: String,
         caption: Option<String>,
+        /// Present for E2EE providers (WhatsApp). When `Some`, `open_image` must
+        /// use the provider client to download and decrypt rather than fetching
+        /// the `url` directly (which would yield encrypted ciphertext).
+        decrypt_params: Option<MediaDecryptParams>,
     },
     File {
         url: String,

--- a/src/providers/telegram/convert.rs
+++ b/src/providers/telegram/convert.rs
@@ -41,16 +41,21 @@ pub fn chat_id_to_peer_id(chat_id: &str) -> Option<i64> {
 }
 
 /// Convert a grammers `Message` to `UnifiedMessage`.
-/// Returns `None` if the message has no usable text content (e.g., service messages we skip).
+/// Always returns `Some`; all message types are mapped to a text representation.
 pub fn grammers_message_to_unified(
     msg: &grammers_client::message::Message,
     chat_id: &str,
 ) -> Option<UnifiedMessage> {
-    // Text content — media becomes "[Media]" placeholder (v1)
-    let text = if msg.text().is_empty() {
-        "[Media]".to_string()
+    // Text content — distinguish photo vs other media (v1: no URL download yet)
+    let content = if !msg.text().is_empty() {
+        MessageContent::Text(msg.text().to_string())
+    } else if msg.photo().is_some() {
+        // TODO(show-picture): Telegram photo download requires grammers client.
+        // For now render as [Image] text. A future iteration can add a proper
+        // download path via the grammers client handle.
+        MessageContent::Text("[Image]".to_string())
     } else {
-        msg.text().to_string()
+        MessageContent::Text("[Media]".to_string())
     };
 
     let sender = msg
@@ -64,7 +69,7 @@ pub fn grammers_message_to_unified(
         chat_id: chat_id.to_string(),
         platform: Platform::Telegram,
         sender,
-        content: MessageContent::Text(text),
+        content,
         // msg.date() already returns DateTime<Utc>
         timestamp: msg.date(),
         status: MessageStatus::Sent,

--- a/src/providers/whatsapp/convert.rs
+++ b/src/providers/whatsapp/convert.rs
@@ -246,12 +246,37 @@ fn extract_message_content(msg: &wa::Message) -> Option<MessageContent> {
     let base = msg.get_base_message();
 
     if let Some(ref img) = base.image_message {
+        // Build decryption params when the proto carries the necessary E2EE fields.
+        // WhatsApp E2EE images always have media_key + direct_path + file_enc_sha256.
+        let decrypt_params = match (
+            img.media_key.as_deref(),
+            img.direct_path.as_deref(),
+            img.file_sha256.as_deref(),
+            img.file_enc_sha256.as_deref(),
+            img.file_length,
+        ) {
+            (Some(key), Some(path), Some(sha256), Some(enc_sha256), Some(len))
+                if !key.is_empty() =>
+            {
+                Some(MediaDecryptParams {
+                    media_key: key.to_vec(),
+                    direct_path: path.to_string(),
+                    file_sha256: sha256.to_vec(),
+                    file_enc_sha256: enc_sha256.to_vec(),
+                    file_length: len,
+                    mime_type: img.mimetype.clone(),
+                })
+            }
+            _ => None,
+        };
+
         if let Some(ref url) = img.url {
             if !url.is_empty() {
                 let caption = img.caption.clone().filter(|s| !s.is_empty());
                 return Some(MessageContent::Image {
                     url: url.clone(),
                     caption,
+                    decrypt_params,
                 });
             }
         }
@@ -321,9 +346,9 @@ mod tests {
     use wa::message::ImageMessage;
     use whatsapp_rust::waproto::whatsapp as wa;
 
-    /// When image_message has a URL, extract_message_content returns Image variant.
+    /// When image_message has a URL but no E2EE keys, decrypt_params is None.
     #[test]
-    fn test_image_message_with_url_returns_image_content() {
+    fn test_image_message_with_url_no_keys_returns_image_content() {
         let mut msg = wa::Message::default();
         let mut img = ImageMessage::default();
         img.url = Some("https://cdn.example.com/img.jpg".to_string());
@@ -331,9 +356,48 @@ mod tests {
         msg.image_message = Some(Box::new(img));
         let content = extract_message_content(&msg).unwrap();
         match content {
-            MessageContent::Image { url, caption } => {
+            MessageContent::Image {
+                url,
+                caption,
+                decrypt_params,
+            } => {
                 assert_eq!(url, "https://cdn.example.com/img.jpg");
                 assert_eq!(caption, Some("A caption".to_string()));
+                assert!(
+                    decrypt_params.is_none(),
+                    "no E2EE keys → decrypt_params should be None"
+                );
+            }
+            other => panic!("Expected Image, got {:?}", other),
+        }
+    }
+
+    /// When image_message has URL + E2EE keys, decrypt_params is populated.
+    #[test]
+    fn test_image_message_with_url_and_keys_returns_decrypt_params() {
+        let mut msg = wa::Message::default();
+        let mut img = ImageMessage::default();
+        img.url = Some("https://mmg.whatsapp.net/enc-blob".to_string());
+        img.media_key = Some(vec![0xAB; 32]);
+        img.direct_path = Some("/v/path/to/media".to_string());
+        img.file_sha256 = Some(vec![0x01; 32]);
+        img.file_enc_sha256 = Some(vec![0x02; 32]);
+        img.file_length = Some(12345);
+        img.mimetype = Some("image/jpeg".to_string());
+        msg.image_message = Some(Box::new(img));
+        let content = extract_message_content(&msg).unwrap();
+        match content {
+            MessageContent::Image {
+                url,
+                decrypt_params,
+                ..
+            } => {
+                assert_eq!(url, "https://mmg.whatsapp.net/enc-blob");
+                let p = decrypt_params.expect("E2EE keys present → decrypt_params should be Some");
+                assert_eq!(p.media_key, vec![0xAB; 32]);
+                assert_eq!(p.direct_path, "/v/path/to/media");
+                assert_eq!(p.file_length, 12345);
+                assert_eq!(p.mime_type, Some("image/jpeg".to_string()));
             }
             other => panic!("Expected Image, got {:?}", other),
         }

--- a/src/providers/whatsapp/convert.rs
+++ b/src/providers/whatsapp/convert.rs
@@ -246,6 +246,16 @@ fn extract_message_content(msg: &wa::Message) -> Option<MessageContent> {
     let base = msg.get_base_message();
 
     if let Some(ref img) = base.image_message {
+        if let Some(ref url) = img.url {
+            if !url.is_empty() {
+                let caption = img.caption.clone().filter(|s| !s.is_empty());
+                return Some(MessageContent::Image {
+                    url: url.clone(),
+                    caption,
+                });
+            }
+        }
+        // Fallback: no URL available — render as text placeholder
         return Some(MessageContent::Text(
             match img.caption.as_deref().filter(|s| !s.is_empty()) {
                 Some(c) => format!("[Image] {}", c),
@@ -303,4 +313,42 @@ fn extract_message_content(msg: &wa::Message) -> Option<MessageContent> {
 /// Strip the @server suffix from a JID string.
 fn strip_jid_server(jid_str: &str) -> String {
     jid_str.split('@').next().unwrap_or(jid_str).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wa::message::ImageMessage;
+    use whatsapp_rust::waproto::whatsapp as wa;
+
+    /// When image_message has a URL, extract_message_content returns Image variant.
+    #[test]
+    fn test_image_message_with_url_returns_image_content() {
+        let mut msg = wa::Message::default();
+        let mut img = ImageMessage::default();
+        img.url = Some("https://cdn.example.com/img.jpg".to_string());
+        img.caption = Some("A caption".to_string());
+        msg.image_message = Some(Box::new(img));
+        let content = extract_message_content(&msg).unwrap();
+        match content {
+            MessageContent::Image { url, caption } => {
+                assert_eq!(url, "https://cdn.example.com/img.jpg");
+                assert_eq!(caption, Some("A caption".to_string()));
+            }
+            other => panic!("Expected Image, got {:?}", other),
+        }
+    }
+
+    /// When image_message has no URL, fall back to Text("[Image]").
+    #[test]
+    fn test_image_message_no_url_falls_back_to_text() {
+        let mut msg = wa::Message::default();
+        let img = ImageMessage::default(); // url = None
+        msg.image_message = Some(Box::new(img));
+        let content = extract_message_content(&msg).unwrap();
+        match content {
+            MessageContent::Text(t) => assert!(t.contains("[Image]")),
+            other => panic!("Expected Text fallback, got {:?}", other),
+        }
+    }
 }

--- a/src/providers/whatsapp/mod.rs
+++ b/src/providers/whatsapp/mod.rs
@@ -10,7 +10,7 @@ use whatsapp_rust::bot::Bot;
 use whatsapp_rust::store::SqliteStore;
 use whatsapp_rust::transport::{TokioWebSocketTransportFactory, UreqHttpClient};
 
-use crate::core::provider::{MessagingProvider, ProviderEvent};
+use crate::core::provider::{MediaBytes, MessagingProvider, ProviderEvent};
 use crate::core::types::*;
 use crate::core::Result;
 
@@ -181,6 +181,29 @@ impl MessagingProvider for WhatsAppProvider {
             .map_err(|e| anyhow::anyhow!("Failed to send read receipt: {}", e))?;
 
         Ok(())
+    }
+
+    async fn download_media(&self, params: &MediaDecryptParams) -> Result<MediaBytes> {
+        use whatsapp_rust::download::MediaType;
+
+        let client = self
+            .client
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("WhatsApp client not connected"))?;
+
+        let bytes = client
+            .download_from_params(
+                &params.direct_path,
+                &params.media_key,
+                &params.file_sha256,
+                &params.file_enc_sha256,
+                params.file_length,
+                MediaType::Image,
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("WhatsApp media download failed: {}", e))?;
+
+        Ok(bytes)
     }
 
     async fn get_chats(&self) -> Result<Vec<UnifiedChat>> {

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -15,6 +15,7 @@ pub enum AppEvent {
     Quit,
     AiSuggestion(String),
     AiError(String),
+    MediaError(String),
 }
 
 pub struct EventHandler {

--- a/src/tui/keybindings.rs
+++ b/src/tui/keybindings.rs
@@ -43,6 +43,7 @@ pub enum Action {
     MessageSelectNext,  // j/Down — move selection down (newer)
     MessageSelectCopy,  // y — copy selected message and exit
     MessageSelectExit,  // Esc — exit without copying
+    OpenMedia,          // Enter — open media attachment in viewer
     ScheduleMessage,    // Ctrl+D — open schedule prompt
     ScheduleInput(KeyEvent),
     ScheduleConfirm,
@@ -175,7 +176,8 @@ fn map_message_select_mode(key: KeyEvent) -> Action {
     match key.code {
         KeyCode::Char('k') | KeyCode::Up => Action::MessageSelectPrev,
         KeyCode::Char('j') | KeyCode::Down => Action::MessageSelectNext,
-        KeyCode::Char('y') | KeyCode::Enter => Action::MessageSelectCopy,
+        KeyCode::Char('y') => Action::MessageSelectCopy,
+        KeyCode::Enter => Action::OpenMedia,
         KeyCode::Esc | KeyCode::Char('q') => Action::MessageSelectExit,
         _ => Action::None,
     }
@@ -206,5 +208,33 @@ fn map_telegram_auth_mode(key: KeyEvent) -> Action {
         KeyCode::Backspace => Action::TelegramAuthBackspace,
         KeyCode::Char(c) => Action::TelegramAuthChar(c),
         _ => Action::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn enter_in_message_select_maps_to_open_media() {
+        let action = map_key(key(KeyCode::Enter), InputMode::MessageSelect, true);
+        assert_eq!(action, Action::OpenMedia);
+    }
+
+    #[test]
+    fn y_in_message_select_maps_to_copy() {
+        let action = map_key(key(KeyCode::Char('y')), InputMode::MessageSelect, true);
+        assert_eq!(action, Action::MessageSelectCopy);
+    }
+
+    #[test]
+    fn esc_in_message_select_maps_to_exit() {
+        let action = map_key(key(KeyCode::Esc), InputMode::MessageSelect, true);
+        assert_eq!(action, Action::MessageSelectExit);
     }
 }

--- a/src/tui/media.rs
+++ b/src/tui/media.rs
@@ -7,34 +7,147 @@ use futures::TryStreamExt;
 use tokio::io::AsyncWriteExt;
 use tokio_util::io::StreamReader;
 
+/// Compute a stable u64 hash of `url` used for cache file naming.
+fn url_hash(url: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    url.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Derive a file extension from a URL path component.
+/// Returns `None` when the URL has no path extension or an unrecognised one.
+fn ext_from_url(url: &str) -> Option<&'static str> {
+    // Strip query/fragment before inspecting the path
+    let path_part = url.split('?').next().unwrap_or(url);
+    let path_part = path_part.split('#').next().unwrap_or(path_part);
+    let lower = path_part.to_lowercase();
+    if lower.ends_with(".jpg") || lower.ends_with(".jpeg") {
+        Some("jpg")
+    } else if lower.ends_with(".png") {
+        Some("png")
+    } else if lower.ends_with(".gif") {
+        Some("gif")
+    } else if lower.ends_with(".webp") {
+        Some("webp")
+    } else if lower.ends_with(".bmp") {
+        Some("bmp")
+    } else {
+        None
+    }
+}
+
+/// Derive a file extension from a `Content-Type` header value.
+fn ext_from_content_type(ct: &str) -> Option<&'static str> {
+    // Content-Type may contain parameters: "image/jpeg; charset=..."
+    let mime = ct.split(';').next().unwrap_or(ct).trim();
+    match mime {
+        "image/jpeg" => Some("jpg"),
+        "image/png" => Some("png"),
+        "image/gif" => Some("gif"),
+        "image/webp" => Some("webp"),
+        "image/bmp" => Some("bmp"),
+        _ => None,
+    }
+}
+
 /// Generate a deterministic temp file path for a given image URL.
-/// Pattern: /tmp/zero-drift-<u64_hash>.jpg
+/// Pattern: /tmp/zero-drift-<u64_hash>.<ext>
+///
+/// `ext` should be derived from the URL path or the HTTP `Content-Type` header
+/// so the saved file has the correct format extension (not always `.jpg`).
 ///
 /// Note: DefaultHasher is not stable across Rust versions; cached files may become
 /// orphans after toolchain upgrades. cleanup_temp_images() handles this after 24h.
-pub fn temp_path_for_url(url: &str) -> PathBuf {
-    let mut hasher = DefaultHasher::new();
-    url.hash(&mut hasher);
-    let hash = hasher.finish();
-    std::env::temp_dir().join(format!("zero-drift-{}.jpg", hash))
+pub fn temp_path_for_url(url: &str, ext: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("zero-drift-{}.{}", url_hash(url), ext))
+}
+
+/// Write `bytes` to a deterministic temp file (keyed on `cache_key`) and open
+/// it with the OS default viewer.
+///
+/// `cache_key` is any string that uniquely identifies this media (e.g. the CDN
+/// URL or the WhatsApp direct_path).  `mime_type` is used to derive the file
+/// extension; falls back to `jpg` when `None` or unrecognised.
+pub async fn open_image_from_bytes(
+    bytes: Vec<u8>,
+    cache_key: &str,
+    mime_type: Option<&str>,
+) -> anyhow::Result<()> {
+    let ext = mime_type
+        .and_then(ext_from_content_type)
+        .unwrap_or("jpg");
+
+    let path = temp_path_for_url(cache_key, ext);
+
+    if !tokio::fs::try_exists(&path).await? {
+        let tmp_path = path.with_extension("tmp");
+        let write_result = async {
+            let mut file = tokio::fs::File::create(&tmp_path).await?;
+            file.write_all(&bytes).await?;
+            file.flush().await?;
+            drop(file);
+            tokio::fs::rename(&tmp_path, &path).await?;
+            Ok::<_, anyhow::Error>(())
+        }
+        .await;
+        if let Err(e) = write_result {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            return Err(e);
+        }
+    }
+
+    spawn_os_opener(&path).await;
+    Ok(())
 }
 
 /// Stream-download `url` to a temp file and open it with the OS default viewer.
+///
+/// The correct file extension is determined by:
+///   1. The URL path (e.g. `.../photo.png` → `png`)
+///   2. The HTTP `Content-Type` response header
+///   3. Fallback to `jpg` when neither is conclusive
 ///
 /// Image bytes flow: network → kernel buffer → disk.
 /// The Rust heap holds only the ~8 KB read buffer inside `tokio::io::copy` —
 /// never the full image.
 pub async fn open_image(url: String) -> anyhow::Result<()> {
-    let path = temp_path_for_url(&url);
+    // Try to determine the extension from the URL before making a request.
+    // If successful we can check the cache immediately; otherwise we must
+    // wait for the response headers to know the real extension.
+    let url_ext = ext_from_url(&url);
 
-    // Download only if not already cached
+    // Fast path: URL extension known and file is already cached.
+    if let Some(ext) = url_ext {
+        let path = temp_path_for_url(&url, ext);
+        if tokio::fs::try_exists(&path).await? {
+            spawn_os_opener(&path).await;
+            return Ok(());
+        }
+    }
+
+    // Issue the HTTP request (needed either because:
+    //   - URL had no recognisable extension, or
+    //   - the cached file does not exist yet).
+    let response = reqwest::get(&url).await?.error_for_status()?;
+
+    // Resolve extension: URL path wins; fall back to Content-Type; default jpg.
+    let ext = url_ext
+        .or_else(|| {
+            response
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .and_then(ext_from_content_type)
+        })
+        .unwrap_or("jpg");
+
+    let path = temp_path_for_url(&url, ext);
+
+    // Re-check cache now that we have the definitive extension.
     if !tokio::fs::try_exists(&path).await? {
         let tmp_path = path.with_extension("tmp");
         let download_result = async {
-            let response = reqwest::get(&url).await?.error_for_status()?;
-            let byte_stream = response
-                .bytes_stream()
-                .map_err(std::io::Error::other);
+            let byte_stream = response.bytes_stream().map_err(std::io::Error::other);
             let mut reader = StreamReader::new(byte_stream);
             let mut file = tokio::fs::File::create(&tmp_path).await?;
             tokio::io::copy(&mut reader, &mut file).await?;
@@ -42,7 +155,8 @@ pub async fn open_image(url: String) -> anyhow::Result<()> {
             drop(file); // close before rename
             tokio::fs::rename(&tmp_path, &path).await?;
             Ok::<_, anyhow::Error>(())
-        }.await;
+        }
+        .await;
         if let Err(e) = download_result {
             // Clean up partial download if any
             let _ = tokio::fs::remove_file(&tmp_path).await;
@@ -57,18 +171,32 @@ pub async fn open_image(url: String) -> anyhow::Result<()> {
 /// Spawn the OS default image viewer for `path` and wait for it to exit.
 /// Uses `spawn_blocking` so the `.wait()` call does not block the async executor.
 /// Waiting prevents zombie processes in the kernel process table.
+///
+/// stdout/stderr of the child process are redirected to /dev/null (Null on
+/// Windows) so that noisy viewers (e.g. Chromium launched via xdg-open) do not
+/// corrupt the TUI terminal output.
 async fn spawn_os_opener(path: &std::path::Path) {
     let path = path.to_path_buf();
     let result = tokio::task::spawn_blocking(move || {
         #[cfg(target_os = "linux")]
-        let spawn_result = std::process::Command::new("xdg-open").arg(&path).spawn();
+        let spawn_result = std::process::Command::new("xdg-open")
+            .arg(&path)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
 
         #[cfg(target_os = "macos")]
-        let spawn_result = std::process::Command::new("open").arg(&path).spawn();
+        let spawn_result = std::process::Command::new("open")
+            .arg(&path)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
 
         #[cfg(target_os = "windows")]
         let spawn_result = std::process::Command::new("cmd")
             .args(["/c", "start", "", &path.to_string_lossy()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
             .spawn();
 
         #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
@@ -131,27 +259,104 @@ pub fn cleanup_temp_images() {
 
 #[cfg(test)]
 mod tests {
-    use super::temp_path_for_url;
+    use super::{ext_from_content_type, ext_from_url, temp_path_for_url};
+
+    // --- temp_path_for_url ---
 
     #[test]
     fn test_temp_path_same_url_gives_same_path() {
-        let a = temp_path_for_url("https://cdn.example.com/img.jpg");
-        let b = temp_path_for_url("https://cdn.example.com/img.jpg");
+        let a = temp_path_for_url("https://cdn.example.com/img.jpg", "jpg");
+        let b = temp_path_for_url("https://cdn.example.com/img.jpg", "jpg");
         assert_eq!(a, b);
     }
 
     #[test]
     fn test_temp_path_different_urls_give_different_paths() {
-        let a = temp_path_for_url("https://cdn.example.com/img1.jpg");
-        let b = temp_path_for_url("https://cdn.example.com/img2.jpg");
+        let a = temp_path_for_url("https://cdn.example.com/img1.jpg", "jpg");
+        let b = temp_path_for_url("https://cdn.example.com/img2.jpg", "jpg");
         assert_ne!(a, b);
     }
 
     #[test]
-    fn test_temp_path_starts_with_tmp_prefix() {
-        let p = temp_path_for_url("https://cdn.example.com/img.jpg");
-        let s = p.to_string_lossy();
-        assert!(s.contains("zero-drift-"), "path should contain zero-drift-: {}", s);
-        assert!(s.ends_with(".jpg"), "path should end with .jpg: {}", s);
+    fn test_temp_path_uses_provided_extension() {
+        let jpg = temp_path_for_url("https://cdn.example.com/img", "jpg");
+        let png = temp_path_for_url("https://cdn.example.com/img", "png");
+        // Same URL → same hash, but different extension
+        let jpg_s = jpg.to_string_lossy();
+        let png_s = png.to_string_lossy();
+        assert!(jpg_s.ends_with(".jpg"), "expected .jpg, got: {}", jpg_s);
+        assert!(png_s.ends_with(".png"), "expected .png, got: {}", png_s);
+        assert!(jpg_s.contains("zero-drift-"), "path should contain zero-drift-: {}", jpg_s);
+    }
+
+    // --- ext_from_url ---
+
+    #[test]
+    fn test_ext_from_url_jpg() {
+        assert_eq!(ext_from_url("https://cdn.example.com/photo.jpg"), Some("jpg"));
+        assert_eq!(ext_from_url("https://cdn.example.com/photo.jpeg"), Some("jpg"));
+        assert_eq!(ext_from_url("https://cdn.example.com/photo.JPG"), Some("jpg"));
+    }
+
+    #[test]
+    fn test_ext_from_url_png() {
+        assert_eq!(ext_from_url("https://cdn.example.com/image.png"), Some("png"));
+    }
+
+    #[test]
+    fn test_ext_from_url_gif() {
+        assert_eq!(ext_from_url("https://cdn.example.com/anim.gif"), Some("gif"));
+    }
+
+    #[test]
+    fn test_ext_from_url_webp() {
+        assert_eq!(ext_from_url("https://cdn.example.com/img.webp"), Some("webp"));
+    }
+
+    #[test]
+    fn test_ext_from_url_strips_query() {
+        assert_eq!(
+            ext_from_url("https://cdn.example.com/photo.png?v=1&x=2"),
+            Some("png")
+        );
+    }
+
+    #[test]
+    fn test_ext_from_url_no_extension() {
+        assert_eq!(ext_from_url("https://cdn.example.com/media/abc123"), None);
+    }
+
+    #[test]
+    fn test_ext_from_url_unknown_extension() {
+        assert_eq!(ext_from_url("https://cdn.example.com/file.tiff"), None);
+    }
+
+    // --- ext_from_content_type ---
+
+    #[test]
+    fn test_ext_from_content_type_jpeg() {
+        assert_eq!(ext_from_content_type("image/jpeg"), Some("jpg"));
+        assert_eq!(ext_from_content_type("image/jpeg; charset=utf-8"), Some("jpg"));
+    }
+
+    #[test]
+    fn test_ext_from_content_type_png() {
+        assert_eq!(ext_from_content_type("image/png"), Some("png"));
+    }
+
+    #[test]
+    fn test_ext_from_content_type_gif() {
+        assert_eq!(ext_from_content_type("image/gif"), Some("gif"));
+    }
+
+    #[test]
+    fn test_ext_from_content_type_webp() {
+        assert_eq!(ext_from_content_type("image/webp"), Some("webp"));
+    }
+
+    #[test]
+    fn test_ext_from_content_type_unknown() {
+        assert_eq!(ext_from_content_type("application/octet-stream"), None);
+        assert_eq!(ext_from_content_type("text/html"), None);
     }
 }

--- a/src/tui/media.rs
+++ b/src/tui/media.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
 use futures::TryStreamExt;
+use tokio::io::AsyncWriteExt;
 use tokio_util::io::StreamReader;
 
 /// Generate a deterministic temp file path for a given image URL.
@@ -37,6 +38,8 @@ pub async fn open_image(url: String) -> anyhow::Result<()> {
             let mut reader = StreamReader::new(byte_stream);
             let mut file = tokio::fs::File::create(&tmp_path).await?;
             tokio::io::copy(&mut reader, &mut file).await?;
+            file.flush().await?;
+            drop(file); // close before rename
             tokio::fs::rename(&tmp_path, &path).await?;
             Ok::<_, anyhow::Error>(())
         }.await;
@@ -47,29 +50,46 @@ pub async fn open_image(url: String) -> anyhow::Result<()> {
         }
     }
 
-    spawn_os_opener(&path);
+    spawn_os_opener(&path).await;
     Ok(())
 }
 
-/// Spawn the OS default image viewer for `path`. Fire-and-forget.
-fn spawn_os_opener(path: &std::path::Path) {
-    #[cfg(target_os = "linux")]
-    let result = std::process::Command::new("xdg-open").arg(path).spawn();
+/// Spawn the OS default image viewer for `path` and wait for it to exit.
+/// Uses `spawn_blocking` so the `.wait()` call does not block the async executor.
+/// Waiting prevents zombie processes in the kernel process table.
+async fn spawn_os_opener(path: &std::path::Path) {
+    let path = path.to_path_buf();
+    let result = tokio::task::spawn_blocking(move || {
+        #[cfg(target_os = "linux")]
+        let spawn_result = std::process::Command::new("xdg-open").arg(&path).spawn();
 
-    #[cfg(target_os = "macos")]
-    let result = std::process::Command::new("open").arg(path).spawn();
+        #[cfg(target_os = "macos")]
+        let spawn_result = std::process::Command::new("open").arg(&path).spawn();
 
-    #[cfg(target_os = "windows")]
-    let result = std::process::Command::new("cmd")
-        .args(["/c", "start", "", &path.to_string_lossy()])
-        .spawn();
+        #[cfg(target_os = "windows")]
+        let spawn_result = std::process::Command::new("cmd")
+            .args(["/c", "start", "", &path.to_string_lossy()])
+            .spawn();
 
-    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-    let result: std::io::Result<std::process::Child> =
-        Err(std::io::Error::new(std::io::ErrorKind::Unsupported, "unsupported OS"));
+        #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+        let spawn_result: std::io::Result<std::process::Child> =
+            Err(std::io::Error::new(std::io::ErrorKind::Unsupported, "unsupported OS"));
+
+        match spawn_result {
+            Ok(mut child) => {
+                // Wait for the opener process to exit so it doesn't become a zombie.
+                // xdg-open / open fork and exit quickly; wait() returns in milliseconds.
+                let _ = child.wait();
+            }
+            Err(e) => {
+                tracing::error!("Failed to spawn OS opener for {:?}: {}", path, e);
+            }
+        }
+    })
+    .await;
 
     if let Err(e) = result {
-        tracing::error!("Failed to spawn OS opener for {:?}: {}", path, e);
+        tracing::error!("spawn_os_opener task panicked: {}", e);
     }
 }
 

--- a/src/tui/media.rs
+++ b/src/tui/media.rs
@@ -1,0 +1,137 @@
+use std::hash::{Hash, Hasher};
+use std::collections::hash_map::DefaultHasher;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+use futures::TryStreamExt;
+use tokio_util::io::StreamReader;
+
+/// Generate a deterministic temp file path for a given image URL.
+/// Pattern: /tmp/zero-drift-<u64_hash>.jpg
+///
+/// Note: DefaultHasher is not stable across Rust versions; cached files may become
+/// orphans after toolchain upgrades. cleanup_temp_images() handles this after 24h.
+pub fn temp_path_for_url(url: &str) -> PathBuf {
+    let mut hasher = DefaultHasher::new();
+    url.hash(&mut hasher);
+    let hash = hasher.finish();
+    std::env::temp_dir().join(format!("zero-drift-{}.jpg", hash))
+}
+
+/// Stream-download `url` to a temp file and open it with the OS default viewer.
+///
+/// Image bytes flow: network → kernel buffer → disk.
+/// The Rust heap holds only the ~8 KB read buffer inside `tokio::io::copy` —
+/// never the full image.
+pub async fn open_image(url: String) -> anyhow::Result<()> {
+    let path = temp_path_for_url(&url);
+
+    // Download only if not already cached
+    if !tokio::fs::try_exists(&path).await? {
+        let tmp_path = path.with_extension("tmp");
+        let download_result = async {
+            let response = reqwest::get(&url).await?.error_for_status()?;
+            let byte_stream = response
+                .bytes_stream()
+                .map_err(std::io::Error::other);
+            let mut reader = StreamReader::new(byte_stream);
+            let mut file = tokio::fs::File::create(&tmp_path).await?;
+            tokio::io::copy(&mut reader, &mut file).await?;
+            tokio::fs::rename(&tmp_path, &path).await?;
+            Ok::<_, anyhow::Error>(())
+        }.await;
+        if let Err(e) = download_result {
+            // Clean up partial download if any
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            return Err(e);
+        }
+    }
+
+    spawn_os_opener(&path);
+    Ok(())
+}
+
+/// Spawn the OS default image viewer for `path`. Fire-and-forget.
+fn spawn_os_opener(path: &std::path::Path) {
+    #[cfg(target_os = "linux")]
+    let result = std::process::Command::new("xdg-open").arg(path).spawn();
+
+    #[cfg(target_os = "macos")]
+    let result = std::process::Command::new("open").arg(path).spawn();
+
+    #[cfg(target_os = "windows")]
+    let result = std::process::Command::new("cmd")
+        .args(["/c", "start", "", &path.to_string_lossy()])
+        .spawn();
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    let result: std::io::Result<std::process::Child> =
+        Err(std::io::Error::new(std::io::ErrorKind::Unsupported, "unsupported OS"));
+
+    if let Err(e) = result {
+        tracing::error!("Failed to spawn OS opener for {:?}: {}", path, e);
+    }
+}
+
+/// Delete `/tmp/zero-drift-*` files older than 24 hours.
+/// Best-effort: all errors are silently logged.
+pub fn cleanup_temp_images() {
+    let cutoff = match SystemTime::now().checked_sub(Duration::from_secs(24 * 3600)) {
+        Some(t) => t,
+        None => return,
+    };
+
+    let tmp = std::env::temp_dir();
+    let entries = match std::fs::read_dir(&tmp) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!("cleanup_temp_images: cannot read {:?}: {}", tmp, e);
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if !name_str.starts_with("zero-drift-") {
+            continue;
+        }
+        let path = entry.path();
+        let mtime = match entry.metadata().and_then(|m| m.modified()) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if mtime < cutoff {
+            if let Err(e) = std::fs::remove_file(&path) {
+                tracing::warn!("cleanup_temp_images: failed to remove {:?}: {}", path, e);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::temp_path_for_url;
+
+    #[test]
+    fn test_temp_path_same_url_gives_same_path() {
+        let a = temp_path_for_url("https://cdn.example.com/img.jpg");
+        let b = temp_path_for_url("https://cdn.example.com/img.jpg");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_temp_path_different_urls_give_different_paths() {
+        let a = temp_path_for_url("https://cdn.example.com/img1.jpg");
+        let b = temp_path_for_url("https://cdn.example.com/img2.jpg");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_temp_path_starts_with_tmp_prefix() {
+        let p = temp_path_for_url("https://cdn.example.com/img.jpg");
+        let s = p.to_string_lossy();
+        assert!(s.contains("zero-drift-"), "path should contain zero-drift-: {}", s);
+        assert!(s.ends_with(".jpg"), "path should end with .jpg: {}", s);
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2,6 +2,7 @@ pub mod app_state;
 pub mod search;
 pub mod event;
 pub mod keybindings;
+pub mod media;
 pub mod osc8;
 pub mod render;
 pub mod time_parse;


### PR DESCRIPTION
## Summary

- WhatsApp image messages can now be opened directly from the TUI by pressing `Enter` on an `[Image]` message in Message Select mode
- Images are downloaded and **end-to-end decrypted** using the WhatsApp media key (AES-256-CBC via the `whatsapp_rust` library) — the raw CDN URL serves only encrypted ciphertext, so direct fetching would yield garbage
- Images without E2EE metadata fall back to a direct CDN fetch (covers non-E2EE providers and some history-sync thumbnails)

## How to use

1. Open a chat containing an image message (shown as `[Image]` or `[Image] caption`)
2. Press `v` to enter **Message Select mode**
3. Navigate with `j` / `k` to the `[Image]` message
4. Press `Enter` — the image is downloaded, decrypted, and opened in your OS default image viewer
5. A **"Opening image..."** status bar flash confirms the download started
6. If anything goes wrong a **"Failed to open image: …"** message is shown in the status bar

## Changes

| File | Change |
|---|---|
| `src/core/types.rs` | Add `MediaDecryptParams` struct; add `decrypt_params: Option<MediaDecryptParams>` field to `MessageContent::Image` |
| `src/providers/whatsapp/convert.rs` | Populate `decrypt_params` from `ImageMessage` proto E2EE fields in `extract_message_content` |
| `src/core/provider.rs` | Add `MediaBytes` type alias and `download_media()` trait method to `Provider` |
| `src/providers/whatsapp/mod.rs` | Implement `download_media()` using `client.download_from_params()` |
| `src/tui/media.rs` | Add `open_image_from_bytes()`: writes bytes to `/tmp/` with correct extension, opens via OS viewer |
| `src/app.rs` | `Action::OpenMedia`: E2EE path → `download_media` + `open_image_from_bytes`; plaintext path → `open_image(url)`; wire `AppEvent::MediaError` |
| `src/tui/event.rs` | Add `MediaError(String)` variant to `AppEvent` |
| `CHANGELOG.md` | v0.3.3 release notes |
| `FEATURES.md` | Document the View Images feature |

## Test plan

- All 69 existing unit tests pass (`cargo test`)
- Manually verified: opened a WhatsApp image with full E2EE keys — image appeared correctly in the OS viewer
- Images stored without E2EE keys (e.g. older history-sync records) open via plaintext CDN path