### PR TITLE
fix: resolve Telegram sender names from chat name cache

### DIFF
--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -5,7 +5,7 @@
 - [ ] **Long message display issue** - Long messages stretch out of the chat panel.
   - Proposed fix: set a max width of 70% of the chat panel width for message bubbles.
 
-- [ ] **Bug: Username shows as `unknown` at Telegram** - User names are not resolved correctly and display as `unknown` in Telegram integration.
+- [x] **Bug: Username shows as `unknown` at Telegram** - User names are not resolved correctly and display as `unknown` in Telegram integration. *(Fixed 2026-03-14)*
 
 ## Completed
 

--- a/src/providers/telegram/convert.rs
+++ b/src/providers/telegram/convert.rs
@@ -28,6 +28,27 @@ impl PeerCache {
     }
 }
 
+/// Maps our `tg-{peer_id}` chat IDs to display names.
+/// Populated during `get_chats()`; used as fallback in message conversion.
+#[derive(Clone, Default)]
+pub struct ChatNameCache {
+    inner: Arc<Mutex<HashMap<String, String>>>,
+}
+
+impl ChatNameCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&self, chat_id: &str, name: &str) {
+        self.inner.lock().unwrap().insert(chat_id.to_string(), name.to_string());
+    }
+
+    pub fn get(&self, chat_id: &str) -> Option<String> {
+        self.inner.lock().unwrap().get(chat_id).cloned()
+    }
+}
+
 /// Encode a Telegram peer id (i64) to our chat_id string format.
 pub fn peer_id_to_chat_id(peer_id: i64) -> String {
     format!("tg-{}", peer_id)
@@ -42,9 +63,11 @@ pub fn chat_id_to_peer_id(chat_id: &str) -> Option<i64> {
 
 /// Convert a grammers `Message` to `UnifiedMessage`.
 /// Always returns `Some`; all message types are mapped to a text representation.
+/// `fallback_name` is used when `msg.sender()` returns `None` (common for channel messages).
 pub fn grammers_message_to_unified(
     msg: &grammers_client::message::Message,
     chat_id: &str,
+    fallback_name: Option<&str>,
 ) -> Option<UnifiedMessage> {
     // Text content — distinguish photo vs other media (v1: no URL download yet)
     let content = if !msg.text().is_empty() {
@@ -62,6 +85,7 @@ pub fn grammers_message_to_unified(
         .sender()
         .and_then(|s| s.name())
         .map(|n| n.to_string())
+        .or_else(|| fallback_name.map(|n| n.to_string()))
         .unwrap_or_else(|| "Unknown".to_string());
 
     Some(UnifiedMessage {

--- a/src/providers/telegram/mod.rs
+++ b/src/providers/telegram/mod.rs
@@ -19,7 +19,7 @@ use crate::core::error::Result;
 use crate::core::provider::{MessagingProvider, ProviderEvent};
 use crate::core::types::*;
 
-use convert::{grammers_message_to_unified, peer_id_to_chat_id, PeerCache};
+use convert::{grammers_message_to_unified, peer_id_to_chat_id, PeerCache, ChatNameCache};
 
 use grammers_client::client::PasswordToken;
 
@@ -218,6 +218,7 @@ pub struct TelegramProvider {
     /// Shared client handle — set by the background task once connected.
     client: Arc<TokioMutex<Option<Client>>>,
     peer_cache: PeerCache,
+    chat_name_cache: ChatNameCache,
     auth_status: AuthStatus,
 
     /// Channel the app uses to push auth answers back into the running start() future.
@@ -237,6 +238,7 @@ impl TelegramProvider {
             session_path: PathBuf::from(session_path),
             client: Arc::new(TokioMutex::new(None)),
             peer_cache: PeerCache::new(),
+            chat_name_cache: ChatNameCache::new(),
             auth_status: AuthStatus::NotAuthenticated,
             auth_tx,
             auth_rx: Some(auth_rx),
@@ -484,7 +486,7 @@ impl TelegramProvider {
                             .map(peer_id_to_chat_id)
                             .unwrap_or_else(|| "tg-unknown".to_string());
 
-                        if let Some(unified) = grammers_message_to_unified(&msg, &chat_id) {
+                        if let Some(unified) = grammers_message_to_unified(&msg, &chat_id, None) {
                             let _ = tx.send(ProviderEvent::NewMessage(unified));
                         }
                     }
@@ -641,6 +643,7 @@ impl MessagingProvider for TelegramProvider {
             self.peer_cache.insert(&chat_id_str, peer_ref);
 
             let name = peer.name().unwrap_or("Unknown").to_string();
+            self.chat_name_cache.insert(&chat_id_str, &name);
 
             let last_message = dialog.last_message.as_ref().map(|m| {
                 if m.text().is_empty() {
@@ -686,13 +689,14 @@ impl MessagingProvider for TelegramProvider {
 
         let mut iter = client.iter_messages(peer).limit(50);
         let mut messages = Vec::new();
+        let fallback = self.chat_name_cache.get(chat_id);
 
         while let Some(msg) = iter
             .next()
             .await
             .map_err(|e| anyhow::anyhow!("iter_messages error: {}", e))?
         {
-            if let Some(unified) = grammers_message_to_unified(&msg, chat_id) {
+            if let Some(unified) = grammers_message_to_unified(&msg, chat_id, fallback.as_deref()) {
                 messages.push(unified);
             }
         }


### PR DESCRIPTION
## Summary

Telegram message sender names were showing as `Unknown` because `msg.sender()` returns `None` for channel messages and history fetches.

This fix introduces a `ChatNameCache` that is populated during `get_chats()` and threaded through to `get_messages()` as a fallback — so when the grammers sender field is absent, the known chat/contact name is used instead.

## Changes

- `src/providers/telegram/convert.rs`
  - Added `ChatNameCache` struct (same pattern as `PeerCache`)
  - Added `fallback_name: Option<&str>` param to `grammers_message_to_unified()`
  - Sender resolution now tries `msg.sender()` first, then fallback, then `"Unknown"`
- `src/providers/telegram/mod.rs`
  - Added `chat_name_cache: ChatNameCache` field to `TelegramProvider`
  - Cache populated in `get_chats()` after name resolution
  - Fallback looked up and passed in `get_messages()`
  - Background event loop call site updated to pass `None`
- `docs/WISHLIST.md` — item marked as completed

## Testing

✅ 69 tests passed, 0 failed

Fixes second item in `docs/WISHLIST.md`