### PR TITLE
docs: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.4] - 2026-03-14
+
+### Fixed
+
+- Long message bubbles now capped at 70% panel width
+- Telegram sender names resolved correctly (no longer shows "Unknown")
+- Windows build failure (bundled SQLite, LNK1181 error resolved)
+- Compiler warnings suppressed (dead_code, unused variable)
+
 ## v0.3.3 — 2026-03-13
 
 ### View images in your terminal chat


### PR DESCRIPTION
Adds CHANGELOG.md seeded with v0.3.4 fixes from 2026-03-14.

### Changes
- Adopted Keep a Changelog format with preamble
- Added [Unreleased] section
- Added [0.3.4] - 2026-03-14 with 4 bug fixes: bubble width, Telegram username resolution, Windows build (LNK1181), compiler warnings