### PR TITLE
feat: --version flag + README CI badge (parallel Sub-Forge T-003)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # zero-drift-chat
 
+[![Build](https://github.com/mgblackwater/zero-drift-chat/actions/workflows/release.yml/badge.svg)](https://github.com/mgblackwater/zero-drift-chat/actions/workflows/release.yml)
+
 A unified messaging TUI built in Rust. Aggregates multiple chat platforms into a single terminal interface.
 
 Currently supports **WhatsApp** via [whatsapp-rust](https://github.com/jlucaso1/whatsapp-rust) (WhatsApp Web multi-device protocol).

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use crate::storage::{AddressBook, Database};
 use crate::tui::event::EventHandler;
 
 #[derive(Parser, Debug)]
-#[command(name = "zero-drift-chat", about = "Unified messaging TUI")]
+#[command(name = "zero-drift-chat", about = "Unified messaging TUI", version)]
 struct Cli {
     /// Path to config file
     #[arg(short, long)]


### PR DESCRIPTION
## Changes

**Module A:** Add `--version` CLI flag printing app version from `CARGO_PKG_VERSION`
**Module B:** Add GitHub Actions CI build status badge to README

Implemented via parallel Sub-Forge worktrees (Phase 3 multi-agent test).