### PR TITLE
feat: --help description + SECURITY.md (full pipeline T-004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--help` flag shows app description via clap (feat/T004-module-a)
+- `SECURITY.md` vulnerability reporting policy (feat/T004-module-b)
+
 ## [0.3.4] - 2026-03-14
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest  | ✅        |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities by opening a **private** GitHub Security Advisory at:
+https://github.com/mgblackwater/zero-drift-chat/security/advisories/new
+
+Do NOT open a public issue for security vulnerabilities.
+
+We aim to respond within 48 hours and will work with you on a fix and coordinated disclosure.

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use crate::storage::{AddressBook, Database};
 use crate::tui::event::EventHandler;
 
 #[derive(Parser, Debug)]
-#[command(name = "zero-drift-chat", about = "Unified messaging TUI", version)]
+#[command(name = "zero-drift-chat", version, about = "Zero-drift chat — a privacy-first terminal messenger")]
 struct Cli {
     /// Path to config file
     #[arg(short, long)]


### PR DESCRIPTION
## Full Pipeline Run — T-004

**Phases completed:** Archivist → Forge (parallel) → Trialmaster → Ethos → Scribe → PR

### Changes
- **Module A:** Improved `--help` output via clap `about` attribute
- **Module B:** Added `SECURITY.md` vulnerability reporting policy
- **Scribe:** CHANGELOG updated

### Pipeline results
- Trialmaster: all tests pass
- Ethos: PASS (no security violations)
- Scribe: CHANGELOG updated