### PR TITLE
fix: Telegram message truncation, unknown sender, and streaming bot responses

### DIFF
--- a/docs/superpowers/specs/2026-03-14-telegram-unicode-truncation-unknown-sender-debug-log-design.md
+++ b/docs/superpowers/specs/2026-03-14-telegram-unicode-truncation-unknown-sender-debug-log-design.md
@@ -1,0 +1,174 @@
+# Design: Telegram Unicode Truncation Fix, Unknown Sender Fix, Debug Logging
+
+**Date:** 2026-03-14  
+**Branch:** fix/telegram-unicode-truncation-debug-log  
+**Status:** Approved
+
+---
+
+## Problem Summary
+
+Three related issues affecting Telegram message display:
+
+1. **Message truncation** — AI-generated bot messages containing emoji and rich Unicode are visually truncated in the TUI. Root cause: `wrap_to_width` and the scroll height estimator operate on **bytes** (`str::len`, `str::split_at`) instead of **display columns**. Each emoji is 4 bytes but 2 display columns; multi-byte splits cause content to be dropped or panic-split mid-codepoint.
+
+2. **Unknown sender still shown** — The `fix/telegram-unknown-username` fix populates `ChatNameCache` and threads it into `get_messages`, but the **live update loop** inside `connect_and_run` calls `grammers_message_to_unified(&msg, &chat_id, None)` — `fallback_name` is always `None` there, so channel messages received in real-time still show "Unknown".
+
+3. **No observability** — There is no way to compare the raw message text as received from Telegram against what the TUI renders, making it hard to diagnose future truncation regressions.
+
+---
+
+## Architecture
+
+No new modules. All changes are contained within:
+
+| File | Change |
+|---|---|
+| `src/tui/widgets/message_view.rs` | Fix `wrap_to_width` and scroll estimator to use `unicode_width` |
+| `src/providers/telegram/mod.rs` | Forward `chat_name_cache` into `connect_and_run`; pass as `fallback_name` in update loop |
+| `src/main.rs` (or init site) | Add optional file tracing subscriber controlled by `ZERO_DRIFT_DEBUG=1` |
+| `Cargo.toml` | Add `unicode-width` dependency (if not already transitive) |
+
+---
+
+## Component Design
+
+### 1. Unicode-aware `wrap_to_width`
+
+**Current (broken):**
+```rust
+let available = max_w.saturating_sub(current.len() + space_needed);
+// ...
+let (chunk, rest) = word_remaining.split_at(available.min(word_remaining.len()));
+```
+
+**Fixed approach:**
+- Measure widths using `unicode_width::UnicodeWidthStr::width(s)` for string width and `unicode_width::UnicodeWidthChar::width(c).unwrap_or(0)` per character.
+- Replace the `split_at(n)` byte-chop with a char-boundary-safe split: accumulate chars until the column budget is exhausted, then `split_at` on the resulting byte offset.
+- `current.len()` → `UnicodeWidthStr::width(current.as_str())`
+
+**Invariant:** The output `Vec<String>` is still valid UTF-8; each string's display width ≤ `max_w` columns.
+
+### 2. Unicode-aware scroll height estimator
+
+**Current (broken):**
+```rust
+let line_width: usize = line.spans.iter().map(|s| s.content.len()).sum();
+```
+
+**Fixed:**
+```rust
+let line_width: usize = line.spans.iter()
+    .map(|s| UnicodeWidthStr::width(s.content.as_ref()))
+    .sum();
+```
+
+This ensures the auto-scroll calculation matches what ratatui actually renders (ratatui uses `unicode_width` internally).
+
+### 3. Forward `chat_name_cache` into `connect_and_run`
+
+`connect_and_run` currently receives `peer_cache` but not `chat_name_cache`. It must:
+1. Accept `chat_name_cache: ChatNameCache` as a new parameter.
+2. Populate it during the dialog iteration loop (same as `get_chats` does).
+3. In the update loop, resolve `fallback_name` from the cache before calling `grammers_message_to_unified`.
+
+```rust
+// In the update loop:
+let fallback = chat_name_cache.get(&chat_id);
+if let Some(unified) = grammers_message_to_unified(&msg, &chat_id, fallback.as_deref()) {
+```
+
+`start()` already clones `peer_cache` before the spawn — add the same clone for `chat_name_cache`.
+
+### 4. Debug file logging
+
+Controlled by env var `ZERO_DRIFT_DEBUG=1`.
+
+In the app's initialization (wherever `tracing_subscriber` is currently configured):
+
+```rust
+if std::env::var("ZERO_DRIFT_DEBUG").is_ok() {
+    // Add a rolling file appender writing to zero-drift-debug.log
+    let file_appender = tracing_appender::rolling::never(".", "zero-drift-debug.log");
+    let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+    // combine with existing subscriber or use a layered approach
+}
+```
+
+Store `_guard` in a top-level variable to keep the background writer alive for the process lifetime.
+
+At message receipt in `grammers_message_to_unified` (or immediately after in `get_messages` / the update loop), emit:
+
+```rust
+tracing::debug!(
+    chat_id = %chat_id,
+    msg_id = %msg.id(),
+    raw_text = %msg.text(),
+    "telegram raw message received"
+);
+```
+
+This logs the **pre-wrap** full text. The TUI renders the post-wrap version. Diffing the log against the TUI output immediately shows whether truncation is in the data layer or the render layer.
+
+**Dependencies to add to `Cargo.toml`:**
+```toml
+unicode-width = "0.2"
+tracing-appender = "0.2"
+```
+
+(`unicode-width` may already be in the lock file transitively via ratatui; either way, declaring it explicitly is correct.)
+
+---
+
+## Data Flow
+
+```
+Telegram MTProto
+      │
+      ▼
+grammers_message_to_unified()
+      │
+      ├─── tracing::debug!(raw_text) ──► zero-drift-debug.log  (when ZERO_DRIFT_DEBUG=1)
+      │
+      ▼
+UnifiedMessage { content: MessageContent::Text(full_text) }
+      │
+      ▼
+render_message_view()
+      │
+      ├── wrap_to_width(text, bubble_max_w)   ← Unicode-column-aware
+      │        └── UnicodeWidthStr::width()
+      │
+      └── scroll estimator                    ← Unicode-column-aware
+               └── UnicodeWidthStr::width()
+```
+
+---
+
+## Error Handling
+
+- `tracing_appender` file creation failure: non-fatal; log a warning to stderr and continue without file logging.
+- `unicode-width` returns 0 for control characters and unprintable codepoints — this is correct behavior (they contribute no visual columns).
+- Characters with `None` width (e.g., combining marks) are treated as 0-width — consistent with terminal behavior.
+
+---
+
+## Testing
+
+### Unit tests — `wrap_to_width`
+Add tests in `message_view.rs`:
+- Single emoji "🎉" at width 2 → fits on one line of max_w=2
+- String of 5 emoji at width 2 each → each on its own line when max_w=2
+- Mixed ASCII + emoji wrapping
+
+### Manual verification
+1. Set `ZERO_DRIFT_DEBUG=1`, open a Telegram bot chat with emoji-heavy messages.
+2. Compare `zero-drift-debug.log` (raw) vs TUI display.
+3. Verify sender name is no longer "Unknown" for channel messages.
+
+---
+
+## Out of Scope
+
+- Downloading and rendering Telegram bot rich-text formatting (bold, italic, inline code) — the grammers `text()` method returns plain text stripped of formatting entities. This is a separate feature.
+- Double-width CJK character handling — `unicode_width` handles this correctly by default; no extra work needed.

--- a/src/app.rs
+++ b/src/app.rs
@@ -460,6 +460,50 @@ impl App {
                         }
                     }
                 }
+                ProviderEvent::MessageUpdated(msg) => {
+                    // Upsert to DB — INSERT OR REPLACE keeps the row current.
+                    if let Err(e) = self.db.insert_message(&msg) {
+                        tracing::debug!("MessageUpdated db upsert: {}", e);
+                    }
+
+                    // Update last_message preview on the chat
+                    let preview = msg.content.as_text().to_string();
+                    if let Some(chat) = self.state.chats.iter_mut().find(|c| c.id == msg.chat_id) {
+                        chat.last_message = Some(preview.clone());
+                    }
+                    let _ = self.db.update_last_message(&msg.chat_id, &preview);
+
+                    // Update message in-place if this chat is currently open
+                    let is_current_chat = self
+                        .state
+                        .selected_chat_id()
+                        .map(|id| id == msg.chat_id)
+                        .unwrap_or(false);
+
+                    if is_current_chat {
+                        if let Some(pos) = self
+                            .state
+                            .messages
+                            .iter()
+                            .position(|m| m.id == msg.id && m.chat_id == msg.chat_id)
+                        {
+                            tracing::debug!(
+                                msg_id = %msg.id,
+                                "MessageUpdated: replacing message at pos {}",
+                                pos
+                            );
+                            self.state.messages[pos] = msg;
+                        } else {
+                            // Edit arrived before history was loaded — push as new.
+                            tracing::debug!(
+                                msg_id = %msg.id,
+                                "MessageUpdated: message not in current view, appending"
+                            );
+                            self.state.messages.push(msg);
+                            self.state.scroll_offset = 0;
+                        }
+                    }
+                }
                 ProviderEvent::ChatsUpdated(chats) => {
                     // Persist and merge — but skip expensive DB reads
                     for chat in &chats {

--- a/src/core/provider.rs
+++ b/src/core/provider.rs
@@ -10,6 +10,9 @@ pub type MediaBytes = Vec<u8>;
 #[derive(Debug, Clone)]
 pub enum ProviderEvent {
     NewMessage(UnifiedMessage),
+    /// An existing message was edited (e.g. a bot streaming its response token-by-token).
+    /// The TUI should replace the message with the same `id` in-place rather than appending.
+    MessageUpdated(UnifiedMessage),
     MessageStatusUpdate {
         message_id: String,
         status: MessageStatus,

--- a/src/providers/telegram/mod.rs
+++ b/src/providers/telegram/mod.rs
@@ -490,6 +490,13 @@ impl TelegramProvider {
 
                         let fallback = chat_name_cache.get(&chat_id);
                         if let Some(unified) = grammers_message_to_unified(&msg, &chat_id, fallback.as_deref()) {
+                            tracing::debug!(
+                                chat_id = %chat_id,
+                                msg_id = %msg.id(),
+                                sender = %unified.sender,
+                                raw_text = %msg.text(),
+                                "telegram raw message (live update)"
+                            );
                             let _ = tx.send(ProviderEvent::NewMessage(unified));
                         }
                     }
@@ -701,6 +708,13 @@ impl MessagingProvider for TelegramProvider {
             .map_err(|e| anyhow::anyhow!("iter_messages error: {}", e))?
         {
             if let Some(unified) = grammers_message_to_unified(&msg, chat_id, fallback.as_deref()) {
+                tracing::debug!(
+                    chat_id = %chat_id,
+                    msg_id = %msg.id(),
+                    sender = %unified.sender,
+                    raw_text = %msg.text(),
+                    "telegram raw message (history)"
+                );
                 messages.push(unified);
             }
         }

--- a/src/providers/telegram/mod.rs
+++ b/src/providers/telegram/mod.rs
@@ -481,48 +481,56 @@ impl TelegramProvider {
         loop {
             match update_stream.next().await {
                 Ok(update) => {
-                    if let grammers_client::update::Update::NewMessage(msg) = update {
-                        let chat_id = msg
-                            .peer_id()
-                            .bot_api_dialog_id()
-                            .map(peer_id_to_chat_id)
-                            .unwrap_or_else(|| "tg-unknown".to_string());
+                    let (msg, is_edit) = match update {
+                        grammers_client::update::Update::NewMessage(m) => (m, false),
+                        grammers_client::update::Update::MessageEdited(m) => (m, true),
+                        _ => continue,
+                    };
 
-                        // Re-fetch the message by ID to get the full text.
-                        // MTProto UpdateNewMessage payloads for bot/channel messages are
-                        // often truncated; the full content requires a GetMessages API call.
-                        let full_msg: Option<grammers_client::message::Message> =
-                            if let Some(peer_ref) = peer_cache.get(&chat_id) {
-                                match client.get_messages_by_id(peer_ref, &[msg.id()]).await {
-                                    Ok(mut msgs) => msgs.pop().flatten(),
-                                    Err(e) => {
-                                        tracing::warn!(
-                                            "get_messages_by_id failed for msg {}: {}; using update payload",
-                                            msg.id(), e
-                                        );
-                                        None
-                                    }
+                    let chat_id = msg
+                        .peer_id()
+                        .bot_api_dialog_id()
+                        .map(peer_id_to_chat_id)
+                        .unwrap_or_else(|| "tg-unknown".to_string());
+
+                    // Re-fetch the message by ID to get the full text.
+                    // Handles both initial truncation (NewMessage) and streaming
+                    // edits (MessageEdited) from bots building up their response.
+                    let full_msg: Option<grammers_client::message::Message> =
+                        if let Some(peer_ref) = peer_cache.get(&chat_id) {
+                            match client.get_messages_by_id(peer_ref, &[msg.id()]).await {
+                                Ok(mut msgs) => msgs.pop().flatten(),
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "get_messages_by_id failed for msg {}: {}; using update payload",
+                                        msg.id(), e
+                                    );
+                                    None
                                 }
-                            } else {
-                                None
-                            };
+                            }
+                        } else {
+                            None
+                        };
 
-                        let effective_msg: &grammers_client::message::Message =
-                            full_msg.as_ref().unwrap_or(&msg);
+                    let effective_msg: &grammers_client::message::Message =
+                        full_msg.as_ref().unwrap_or(&msg);
 
-                        let fallback = chat_name_cache.get(&chat_id);
-                        if let Some(unified) = grammers_message_to_unified(effective_msg, &chat_id, fallback.as_deref()) {
-                            tracing::debug!(
-                                chat_id = %chat_id,
-                                msg_id = %effective_msg.id(),
-                                sender = %unified.sender,
-                                raw_text = %effective_msg.text(),
-                                "telegram raw message (live update)"
-                            );
+                    let fallback = chat_name_cache.get(&chat_id);
+                    if let Some(unified) = grammers_message_to_unified(effective_msg, &chat_id, fallback.as_deref()) {
+                        tracing::debug!(
+                            chat_id = %chat_id,
+                            msg_id = %effective_msg.id(),
+                            sender = %unified.sender,
+                            is_edit = %is_edit,
+                            raw_text = %effective_msg.text(),
+                            "telegram raw message (live update)"
+                        );
+                        if is_edit {
+                            let _ = tx.send(ProviderEvent::MessageUpdated(unified));
+                        } else {
                             let _ = tx.send(ProviderEvent::NewMessage(unified));
                         }
                     }
-                    // Other update kinds are ignored for now.
                 }
                 Err(e) => {
                     tracing::warn!("Telegram update stream error: {}; stopping", e);

--- a/src/providers/telegram/mod.rs
+++ b/src/providers/telegram/mod.rs
@@ -366,6 +366,7 @@ impl TelegramProvider {
         api_hash: String,
         session_path: PathBuf,
         peer_cache: PeerCache,
+        chat_name_cache: ChatNameCache,
         client_slot: Arc<TokioMutex<Option<Client>>>,
         mut auth_rx: mpsc::UnboundedReceiver<AuthInput>,
         tx: mpsc::UnboundedSender<ProviderEvent>,
@@ -439,6 +440,7 @@ impl TelegramProvider {
             peer_cache.insert(&chat_id_str, peer_ref);
 
             let name = peer.name().unwrap_or("Unknown").to_string();
+            chat_name_cache.insert(&chat_id_str, &name);
             let last_message = dialog.last_message.as_ref().map(|m| {
                 if m.text().is_empty() {
                     "[Media]".to_string()
@@ -486,7 +488,8 @@ impl TelegramProvider {
                             .map(peer_id_to_chat_id)
                             .unwrap_or_else(|| "tg-unknown".to_string());
 
-                        if let Some(unified) = grammers_message_to_unified(&msg, &chat_id, None) {
+                        let fallback = chat_name_cache.get(&chat_id);
+                        if let Some(unified) = grammers_message_to_unified(&msg, &chat_id, fallback.as_deref()) {
                             let _ = tx.send(ProviderEvent::NewMessage(unified));
                         }
                     }
@@ -538,6 +541,7 @@ impl MessagingProvider for TelegramProvider {
         let api_hash = self.api_hash.clone();
         let session_path = self.session_path.clone();
         let peer_cache = self.peer_cache.clone();
+        let chat_name_cache = self.chat_name_cache.clone();
         let client_slot = Arc::clone(&self.client);
         let auth_rx = self
             .auth_rx
@@ -548,7 +552,7 @@ impl MessagingProvider for TelegramProvider {
         // start() returns immediately and the TUI can draw before auth is needed.
         let connect_handle = tokio::spawn(async move {
             match Self::connect_and_run(
-                api_id, api_hash, session_path, peer_cache, client_slot, auth_rx, tx.clone(),
+                api_id, api_hash, session_path, peer_cache, chat_name_cache, client_slot, auth_rx, tx.clone(),
             )
             .await
             {

--- a/src/providers/telegram/mod.rs
+++ b/src/providers/telegram/mod.rs
@@ -488,13 +488,35 @@ impl TelegramProvider {
                             .map(peer_id_to_chat_id)
                             .unwrap_or_else(|| "tg-unknown".to_string());
 
+                        // Re-fetch the message by ID to get the full text.
+                        // MTProto UpdateNewMessage payloads for bot/channel messages are
+                        // often truncated; the full content requires a GetMessages API call.
+                        let full_msg: Option<grammers_client::message::Message> =
+                            if let Some(peer_ref) = peer_cache.get(&chat_id) {
+                                match client.get_messages_by_id(peer_ref, &[msg.id()]).await {
+                                    Ok(mut msgs) => msgs.pop().flatten(),
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            "get_messages_by_id failed for msg {}: {}; using update payload",
+                                            msg.id(), e
+                                        );
+                                        None
+                                    }
+                                }
+                            } else {
+                                None
+                            };
+
+                        let effective_msg: &grammers_client::message::Message =
+                            full_msg.as_ref().unwrap_or(&msg);
+
                         let fallback = chat_name_cache.get(&chat_id);
-                        if let Some(unified) = grammers_message_to_unified(&msg, &chat_id, fallback.as_deref()) {
+                        if let Some(unified) = grammers_message_to_unified(effective_msg, &chat_id, fallback.as_deref()) {
                             tracing::debug!(
                                 chat_id = %chat_id,
-                                msg_id = %msg.id(),
+                                msg_id = %effective_msg.id(),
                                 sender = %unified.sender,
-                                raw_text = %msg.text(),
+                                raw_text = %effective_msg.text(),
                                 "telegram raw message (live update)"
                             );
                             let _ = tx.send(ProviderEvent::NewMessage(unified));

--- a/src/tui/widgets/message_view.rs
+++ b/src/tui/widgets/message_view.rs
@@ -7,6 +7,8 @@ use ratatui::{
     Frame,
 };
 
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
 use crate::core::types::UnifiedMessage;
 use crate::tui::app_state::ActivePanel;
 
@@ -28,39 +30,48 @@ fn wrap_to_width(text: &str, max_w: usize) -> Vec<String> {
             continue;
         }
         let mut current = String::new();
+        let mut current_w: usize = 0;
         for word in original_line.split_whitespace() {
-            // Handle words longer than max_w: chop them
-            let mut word_remaining = word;
-            while !word_remaining.is_empty() {
-                let space_needed = if current.is_empty() { 0 } else { 1 };
-                let available = max_w.saturating_sub(current.len() + space_needed);
-                if available == 0 {
-                    // Flush current line
+            let word_w = UnicodeWidthStr::width(word);
+            let space_needed = if current.is_empty() { 0 } else { 1 };
+            if current_w + space_needed + word_w <= max_w {
+                // Word fits on current line
+                if !current.is_empty() {
+                    current.push(' ');
+                    current_w += 1;
+                }
+                current.push_str(word);
+                current_w += word_w;
+            } else if word_w > max_w {
+                // Word wider than max_w: flush current, then chop word char by char
+                if !current.is_empty() {
                     lines.push(current.clone());
                     current.clear();
-                    continue;
+                    current_w = 0;
                 }
-                if word_remaining.len() <= available {
-                    if !current.is_empty() {
-                        current.push(' ');
+                let mut chunk = String::new();
+                let mut chunk_w: usize = 0;
+                for ch in word.chars() {
+                    let ch_w = UnicodeWidthChar::width(ch).unwrap_or(0);
+                    if chunk_w + ch_w > max_w {
+                        lines.push(chunk.clone());
+                        chunk.clear();
+                        chunk_w = 0;
                     }
-                    current.push_str(word_remaining);
-                    word_remaining = "";
-                } else {
-                    // Check if word fits on a fresh line
-                    if current.is_empty() {
-                        // Force chop
-                        let (chunk, rest) = word_remaining.split_at(available.min(word_remaining.len()));
-                        current.push_str(chunk);
-                        lines.push(current.clone());
-                        current.clear();
-                        word_remaining = rest;
-                    } else {
-                        // Flush and retry on fresh line
-                        lines.push(current.clone());
-                        current.clear();
-                    }
+                    chunk.push(ch);
+                    chunk_w += ch_w;
                 }
+                if !chunk.is_empty() {
+                    current = chunk;
+                    current_w = chunk_w;
+                }
+            } else {
+                // Word doesn't fit on current line; flush and start fresh
+                if !current.is_empty() {
+                    lines.push(current.clone());
+                }
+                current = word.to_string();
+                current_w = word_w;
             }
         }
         if !current.is_empty() || lines.last().map(|l: &String| !l.is_empty()).unwrap_or(true) {
@@ -247,25 +258,24 @@ pub fn render_message_view(
         let bubble_max_w = (content_width * 70 / 100).max(20);
 
         for original_line in msg.content.as_text().split('\n') {
-        for text_line in wrap_to_width(original_line, bubble_max_w) {
-        let text_line = &text_line;
-            let line = if !text_line.contains("http://") && !text_line.contains("https://") {
-                if is_selected && !msg.is_outgoing {
-                    Line::from(vec![
-                        Span::styled(gutter, gutter_style),
-                        Span::styled(text_line.to_string(), select_bg.fg(msg_color)),
-                    ])
-                } else if is_selected {
-                    Line::from(Span::styled(text_line.to_string(), select_bg.fg(msg_color)))
-                } else {
-                    Line::from(Span::styled(
-                        text_line.to_string(),
-                        Style::default().fg(msg_color),
-                    ))
-                }
-            } else {
-                let spans: Vec<Span> =
+            for text_line in wrap_to_width(original_line, bubble_max_w) {
+                let text_line = &text_line;
+                let line = if !text_line.contains("http://") && !text_line.contains("https://") {
                     if is_selected && !msg.is_outgoing {
+                        Line::from(vec![
+                            Span::styled(gutter, gutter_style),
+                            Span::styled(text_line.to_string(), select_bg.fg(msg_color)),
+                        ])
+                    } else if is_selected {
+                        Line::from(Span::styled(text_line.to_string(), select_bg.fg(msg_color)))
+                    } else {
+                        Line::from(Span::styled(
+                            text_line.to_string(),
+                            Style::default().fg(msg_color),
+                        ))
+                    }
+                } else {
+                    let spans: Vec<Span> = if is_selected && !msg.is_outgoing {
                         let mut s = vec![Span::styled(gutter, gutter_style)];
                         s.extend(split_line_with_urls(text_line).into_iter().map(
                             |(seg, is_url)| {
@@ -310,14 +320,14 @@ pub fn render_message_view(
                             })
                             .collect()
                     };
-                Line::from(spans)
-            };
-            if msg.is_outgoing {
-                lines.push(line.alignment(Alignment::Right));
-            } else {
-                lines.push(line);
-            }
-        } // end wrap_to_width loop
+                    Line::from(spans)
+                };
+                if msg.is_outgoing {
+                    lines.push(line.alignment(Alignment::Right));
+                } else {
+                    lines.push(line);
+                }
+            } // end wrap_to_width loop
         } // end original_line loop
         lines.push(Line::from("")); // spacing
     }
@@ -340,7 +350,11 @@ pub fn render_message_view(
             if content_width == 0 {
                 return 1;
             }
-            let line_width: usize = line.spans.iter().map(|s| s.content.len()).sum();
+            let line_width: usize = line
+                .spans
+                .iter()
+                .map(|s| UnicodeWidthStr::width(s.content.as_ref()))
+                .sum();
             if line_width == 0 {
                 1
             } else {
@@ -490,5 +504,33 @@ mod tests {
         let result = wrap_to_width("one two three four", 9);
         // "one two" = 7, "three" = 5 (fits alone), "four" = 4
         assert_eq!(result, vec!["one two", "three", "four"]);
+    }
+
+    #[test]
+    fn wrap_single_emoji_fits_at_width_2() {
+        // "🎉" has display width 2; should fit on one line when max_w=2
+        assert_eq!(wrap_to_width("🎉", 2), vec!["🎉"]);
+    }
+
+    #[test]
+    fn wrap_emoji_string_each_on_own_line() {
+        // Five emoji at width 2 each; max_w=2 → one per line
+        assert_eq!(
+            wrap_to_width("🎉🎊🎈🎁🎀", 2),
+            vec!["🎉", "🎊", "🎈", "🎁", "🎀"]
+        );
+    }
+
+    #[test]
+    fn wrap_mixed_ascii_emoji() {
+        // "hi 🎉" — "hi" is 2 cols, space+emoji pushes to 5 cols total; max_w=4
+        // "hi" fits, "🎉" goes to next line
+        assert_eq!(wrap_to_width("hi 🎉", 4), vec!["hi", "🎉"]);
+    }
+
+    #[test]
+    fn wrap_emoji_does_not_split_mid_codepoint() {
+        // "🎉🎊" at max_w=3 — "🎉" is width 2 (fits), "🎊" is width 2 (new line)
+        assert_eq!(wrap_to_width("🎉🎊", 3), vec!["🎉", "🎊"]);
     }
 }


### PR DESCRIPTION
## Summary

- **Fix Unicode truncation in TUI**: `wrap_to_width()` was using byte `.len()` and `.split_at()` — replaced with `UnicodeWidthStr::width()` and char-by-char iteration so emoji and multi-byte characters wrap correctly
- **Fix \"Unknown\" sender on live messages**: `chat_name_cache` was not forwarded into `connect_and_run`, so all live `UpdateNewMessage` events resolved to `None` → \"Unknown\"; now the cache is cloned in and populated during dialog iteration
- **Add debug logging**: Raw Telegram message content (text, sender, msg_id) is logged at `debug` level to `~/.zero-drift-chat/zero-drift.log` when running with `--debug`
- **Re-fetch full message on live update**: MTProto `UpdateNewMessage` payloads for bot/channel messages are truncated previews; added `get_messages_by_id` re-fetch on arrival
- **Handle streaming bot responses (`UpdateEditMessage`)**: Bots stream responses by repeatedly editing the same message ID. The app now handles `Update::MessageEdited`, re-fetches the current full text, and emits `ProviderEvent::MessageUpdated` which updates the message in-place in the TUI rather than being ignored

## Testing

Run with `--debug` and open a Telegram chat with a bot (e.g. Arc). Trigger a long response and observe:
- Message appears and grows in-place as the bot streams
- No duplicate messages for the same message ID
- `~/.zero-drift-chat/zero-drift.log` shows `is_edit=true` log lines with the same `msg_id` and progressively longer `raw_text`