### PR TITLE
feat: typing indicator with running-light chaser animation

### DIFF
--- a/docs/superpowers/plans/2026-03-16-typing-indicator-running-light.md
+++ b/docs/superpowers/plans/2026-03-16-typing-indicator-running-light.md
@@ -1,0 +1,165 @@
+# Typing Indicator Running Light Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single green↔gray blinking dot with a 3-dot running-light (chaser) animation where one green dot sweeps left→right across three dim dots.
+
+**Architecture:** Change `blink_phase` from `bool` to `u8` (0/1/2) throughout the codebase. The tick handler advances the phase by 1 mod 3 every 2 ticks. The chat list widget renders three `●` spans, coloring the one at index `phase` green and the others `DarkGray`.
+
+**Tech Stack:** Rust, ratatui 0.29, tokio (250ms tick rate)
+
+---
+
+## Chunk 1: All changes (single task — small scope)
+
+### Task 1: Upgrade blink_phase to u8 and render 3-dot chaser
+
+**Files:**
+- Modify: `src/tui/app_state.rs:361-362` (field type + doc comment), `398` (init), `581` (test)
+- Modify: `src/app.rs:357-359` (tick handler toggle)
+- Modify: `src/tui/widgets/chat_list.rs:14` (signature), `56-76` (spans), `88` (render_chat_list param)
+
+> `src/tui/render.rs` needs no change — it passes `state.blink_phase` by value; the type flows automatically.
+
+---
+
+- [ ] **Step 1.1: Update `blink_phase` field in `AppState`**
+
+Open `src/tui/app_state.rs`. Make three edits:
+
+**Edit 1** — field declaration (line 361–362):
+```rust
+// before
+    /// Toggled every 2 ticks (~500ms) to drive the green↔gray blink animation.
+    pub blink_phase: bool,
+
+// after
+    /// Running-light phase: 0=first dot lit, 1=middle, 2=last. Cycles every 2 ticks (~500ms/step).
+    pub blink_phase: u8,
+```
+
+**Edit 2** — initializer (line 398):
+```rust
+// before
+            blink_phase: false,
+
+// after
+            blink_phase: 0,
+```
+
+**Edit 3** — existing unit test assertion (line 581):
+```rust
+// before
+        assert!(!state.blink_phase);
+
+// after
+        assert_eq!(state.blink_phase, 0);
+```
+
+---
+
+- [ ] **Step 1.2: Update tick handler in `App`**
+
+Open `src/app.rs` lines 357–359. Replace the toggle:
+
+```rust
+// before
+        if self.tick_count % 2 == 0 {
+            self.state.blink_phase = !self.state.blink_phase;
+        }
+
+// after
+        if self.tick_count % 2 == 0 {
+            self.state.blink_phase = (self.state.blink_phase + 1) % 3;
+        }
+```
+
+---
+
+- [ ] **Step 1.3: Update `make_item` and `render_chat_list` in `chat_list.rs`**
+
+Open `src/tui/widgets/chat_list.rs`. Make two edits:
+
+**Edit 1** — `make_item` signature (line 14):
+```rust
+// before
+fn make_item(chat: &UnifiedChat, is_selected: bool, typing_blink: Option<bool>) -> ListItem<'static> {
+
+// after
+fn make_item(chat: &UnifiedChat, is_selected: bool, typing_blink: Option<u8>) -> ListItem<'static> {
+```
+
+**Edit 2** — typing branch of `spans` (lines 56–66). Replace:
+```rust
+    let spans = if let Some(phase) = typing_blink {
+        let dot_color = if phase { Color::Green } else { Color::DarkGray };
+        vec![
+            Span::raw(selector),
+            Span::styled(pin_tag.to_string(), Style::default().fg(Color::Yellow)),
+            platform_span,
+            emoji_span,
+            Span::styled("● ", Style::default().fg(dot_color)),
+            Span::styled(name, Style::default().fg(name_color)),
+            Span::styled(" typing", Style::default().fg(Color::DarkGray)),
+        ]
+```
+
+with:
+```rust
+    let spans = if let Some(phase) = typing_blink {
+        let dot = |i: u8| {
+            let color = if phase == i { Color::Green } else { Color::DarkGray };
+            Span::styled("● ", Style::default().fg(color))
+        };
+        vec![
+            Span::raw(selector),
+            Span::styled(pin_tag.to_string(), Style::default().fg(Color::Yellow)),
+            platform_span,
+            emoji_span,
+            dot(0),
+            dot(1),
+            dot(2),
+            Span::styled(name, Style::default().fg(name_color)),
+            Span::styled(" typing", Style::default().fg(Color::DarkGray)),
+        ]
+```
+
+**Edit 3** — `render_chat_list` parameter (line 88):
+```rust
+// before
+    blink_phase: bool,
+
+// after
+    blink_phase: u8,
+```
+
+> The three `make_item` call sites (`typing_states.get(&chat.id).map(|_| blink_phase)`) need no changes — the closure body is unchanged, only the inferred type changes.
+
+---
+
+- [ ] **Step 1.4: Verify compilation**
+
+```bash
+cargo check 2>&1 | head -30
+```
+
+Expected: zero errors. There may be a warning about `dot` closure — that's fine.
+
+---
+
+- [ ] **Step 1.5: Run all tests**
+
+```bash
+cargo test 2>&1 | tail -10
+```
+
+Expected: `82 passed; 0 failed`
+
+---
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add src/tui/app_state.rs src/app.rs src/tui/widgets/chat_list.rs
+git commit -m "feat: replace blink dot with 3-dot running-light chaser animation"
+```

--- a/docs/superpowers/plans/2026-03-16-typing-indicator.md
+++ b/docs/superpowers/plans/2026-03-16-typing-indicator.md
@@ -1,0 +1,740 @@
+# Typing Indicator Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a pulsing green dot + "typing" label in the chat list when a Telegram or WhatsApp contact is typing, disappearing automatically after 5 seconds.
+
+**Architecture:** A new `ProviderEvent::Typing` variant is fired by Telegram (via `Update::Raw` TL downcasting) and WhatsApp (via `Event::ChatPresence`). `AppState` holds a `HashMap<String, TypingInfo>` keyed by chat ID; expired entries are cleaned up on each 250ms tick. A `blink_phase: bool` (toggled every 2 ticks) drives the green↔gray animation. The chat list widget reads both fields to render the indicator inline with the chat name.
+
+**Tech Stack:** Rust, ratatui 0.29, grammers (Telegram MTProto), whatsapp-rust, tokio
+
+---
+
+## Chunk 1: Core data model + event plumbing
+
+### Task 1: Add `ProviderEvent::Typing` to the event enum
+
+**Files:**
+- Modify: `src/core/provider.rs:11-33`
+
+- [ ] **Step 1.1: Add the new variant**
+
+Open `src/core/provider.rs`. The `ProviderEvent` enum ends at line 33. Add the new variant before the closing `}`:
+
+```rust
+    /// A contact in the given chat is currently typing.
+    /// Fires on each typing update from the platform; the TUI expires the
+    /// indicator automatically after 5 seconds without a new event.
+    Typing { chat_id: String, user_name: String },
+```
+
+The full enum after the change:
+```rust
+#[derive(Debug, Clone)]
+pub enum ProviderEvent {
+    NewMessage(UnifiedMessage),
+    MessageUpdated(UnifiedMessage),
+    MessageStatusUpdate {
+        message_id: String,
+        status: MessageStatus,
+    },
+    ChatsUpdated(Vec<UnifiedChat>),
+    AuthStatusChanged(Platform, AuthStatus),
+    AuthQrCode(String),
+    SyncCompleted,
+    SelfRead { chat_id: String },
+    AuthPhonePrompt(Platform, Option<String>),
+    AuthOtpPrompt(Platform, Option<String>),
+    AuthPasswordPrompt(Platform, Option<String>),
+    LidPnMappingDiscovered { lid: String, pn: String },
+    /// A contact in the given chat is currently typing.
+    Typing { chat_id: String, user_name: String },
+}
+```
+
+- [ ] **Step 1.2: Verify it compiles**
+
+```bash
+cargo check 2>&1 | head -30
+```
+
+Expected: warning about non-exhaustive match patterns in `src/app.rs` (the `handle_tick` event dispatch doesn't handle `Typing` yet). No errors beyond that.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add src/core/provider.rs
+git commit -m "feat: add ProviderEvent::Typing variant for typing indicators"
+```
+
+---
+
+### Task 2: Add `TypingInfo` and new fields to `AppState`
+
+**Files:**
+- Modify: `src/tui/app_state.rs:1-6` (imports), `317-347` (struct), `354-381` (`new()`)
+
+- [ ] **Step 2.1: Add `Instant` and `HashMap` imports**
+
+At the top of `src/tui/app_state.rs`, the current imports are:
+```rust
+use ratatui::widgets::ListState;
+use tui_textarea::TextArea;
+
+use crate::config::AppConfig;
+use crate::core::types::{Platform, UnifiedChat, UnifiedMessage};
+use crate::storage::ScheduledMessage;
+```
+
+Change to:
+```rust
+use std::collections::HashMap;
+use std::time::Instant;
+
+use ratatui::widgets::ListState;
+use tui_textarea::TextArea;
+
+use crate::config::AppConfig;
+use crate::core::types::{Platform, UnifiedChat, UnifiedMessage};
+use crate::storage::ScheduledMessage;
+```
+
+- [ ] **Step 2.2: Add `TypingInfo` struct**
+
+After the last `use` statement and before the first `#[derive]` line in the file (line 8, the `InputMode` enum), insert:
+
+```rust
+/// Tracks a contact who is currently typing in a chat.
+#[derive(Debug, Clone)]
+pub struct TypingInfo {
+    pub user_name: String,
+    pub expires_at: Instant,
+}
+```
+
+- [ ] **Step 2.3: Add fields to `AppState` struct**
+
+At the end of the `AppState` struct (after `pub schedule_status: Option<String>`), add:
+
+```rust
+    /// Per-chat typing indicators: chat_id → who is typing and when it expires.
+    pub typing_states: HashMap<String, TypingInfo>,
+    /// Toggled every 2 ticks (~500ms) to drive the green↔gray blink animation.
+    pub blink_phase: bool,
+```
+
+- [ ] **Step 2.4: Initialize in `AppState::new()`**
+
+In the `Self { ... }` block of `AppState::new()`, after `schedule_status: None,` add:
+
+```rust
+            typing_states: HashMap::new(),
+            blink_phase: false,
+```
+
+- [ ] **Step 2.5: Write a unit test**
+
+At the end of `src/tui/app_state.rs`, add:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_app_state_new_has_empty_typing_states() {
+        let state = AppState::new();
+        assert!(state.typing_states.is_empty());
+        assert!(!state.blink_phase);
+    }
+
+    #[test]
+    fn test_typing_info_expiry() {
+        let expired = TypingInfo {
+            user_name: "Alice".to_string(),
+            expires_at: Instant::now() - Duration::from_secs(1),
+        };
+        let active = TypingInfo {
+            user_name: "Bob".to_string(),
+            expires_at: Instant::now() + Duration::from_secs(5),
+        };
+        let now = Instant::now();
+        assert!(expired.expires_at <= now, "expired entry should be in the past");
+        assert!(active.expires_at > now, "active entry should be in the future");
+    }
+}
+```
+
+- [ ] **Step 2.6: Run the tests**
+
+```bash
+cargo test tui::app_state::tests -- --nocapture
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add src/tui/app_state.rs
+git commit -m "feat: add TypingInfo struct and typing_states/blink_phase to AppState"
+```
+
+---
+
+### Task 3: Wire tick handler and event dispatch in `App`
+
+**Files:**
+- Modify: `src/app.rs:34-48` (struct), `84-98` (`new()`), `337-351` (`handle_tick`), `648-651` (event match end)
+
+- [ ] **Step 3.1: Add `tick_count` field to `App` struct**
+
+In `src/app.rs`, the `App` struct (lines 34–48) currently ends with `event_tx`. Add `tick_count` before the closing `}`:
+
+```rust
+pub struct App {
+    state: AppState,
+    router: MessageRouter,
+    db: Database,
+    address_book: AddressBook,
+    config: AppConfig,
+    config_path: PathBuf,
+    ai_worker: Option<AiWorker>,
+    last_keystroke: Option<Instant>,
+    db_summary_tx: tokio::sync::mpsc::UnboundedSender<(String, String)>,
+    db_summary_rx: tokio::sync::mpsc::UnboundedReceiver<(String, String)>,
+    schedule_status_ticks: u8,
+    tick_count: u64,    // <-- new
+    telegram_auth_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::providers::telegram::AuthInput>>,
+    event_tx: tokio::sync::mpsc::UnboundedSender<AppEvent>,
+}
+```
+
+- [ ] **Step 3.2: Initialize `tick_count` in `App::new()`**
+
+In the `Self { ... }` block of `App::new()`, after `schedule_status_ticks: 0,` add:
+
+```rust
+            tick_count: 0,
+```
+
+- [ ] **Step 3.3: Add required imports to `app.rs`**
+
+At the top of `src/app.rs`, find the existing imports and verify `Duration` and `TypingInfo` are available. Add to the `use crate::tui::app_state` import line:
+
+```rust
+use crate::tui::app_state::{AppState, InputMode, TypingInfo};
+```
+
+Also confirm `std::time::{Duration, Instant}` is already imported (it is — check for `Instant` usage). If `Duration` is not imported, add it.
+
+- [ ] **Step 3.4: Add tick_count increment and typing expiry to `handle_tick`**
+
+The `handle_tick` function starts at line 337. After the `schedule_status_ticks` block and before `let events = self.router.poll_events();`, add:
+
+```rust
+        // Advance tick counter and drive typing indicator animation
+        self.tick_count += 1;
+        let now = std::time::Instant::now();
+        self.state.typing_states.retain(|_, v| v.expires_at > now);
+        if self.tick_count % 2 == 0 {
+            self.state.blink_phase = !self.state.blink_phase;
+        }
+```
+
+- [ ] **Step 3.5: Handle `ProviderEvent::Typing` in the event dispatch**
+
+The event dispatch match in `handle_tick` ends at line 648–651:
+```rust
+                ProviderEvent::LidPnMappingDiscovered { lid, pn } => {
+                    ...
+                }
+            }   // ← end of match event
+        }       // ← end of for event in events
+    }           // ← end of handle_tick
+```
+
+Before the final `}` of the `match event` block (after the `LidPnMappingDiscovered` arm), add:
+
+```rust
+                ProviderEvent::Typing { chat_id, user_name } => {
+                    self.state.typing_states.insert(chat_id, TypingInfo {
+                        user_name,
+                        expires_at: std::time::Instant::now() + std::time::Duration::from_secs(5),
+                    });
+                }
+```
+
+- [ ] **Step 3.6: Verify it compiles**
+
+```bash
+cargo check 2>&1 | head -30
+```
+
+Expected: clean compile (no errors). There may be warnings about unused imports — those are fine for now.
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add src/app.rs
+git commit -m "feat: add tick_count to App, expire typing indicators on tick, handle ProviderEvent::Typing"
+```
+
+---
+
+## Chunk 2: Platform provider implementations
+
+### Task 4: Telegram — handle typing updates via `Update::Raw`
+
+**Files:**
+- Modify: `src/providers/telegram/mod.rs:481-540`
+
+**Context:** The update loop currently lives inside `match update_stream.next().await { Ok(update) => { ... } }` (lines 482–534). The entire `Ok(update) => { ... }` arm must be restructured: add an `if let Update::Raw` guard before the existing message-binding `match`.
+
+- [ ] **Step 4.1: Replace the `Ok(update) =>` arm**
+
+Find lines 483–534 in `src/providers/telegram/mod.rs`. Replace the entire `Ok(update) => { ... }` block with:
+
+```rust
+                Ok(update) => {
+                    // Handle Raw typing updates first (borrow avoids moving `update`).
+                    // The `continue` skips the message-processing path below.
+                    if let grammers_client::update::Update::Raw(raw) = &update {
+                        match &raw.raw {
+                            tl::enums::Update::UserTyping(u) => {
+                                // Private chat: chat_id derived from the peer user id
+                                let chat_id = peer_id_to_chat_id(u.user_id);
+                                let user_name = chat_name_cache
+                                    .get(&chat_id)
+                                    .cloned()
+                                    .unwrap_or_else(|| format!("User {}", u.user_id));
+                                let _ = tx.send(ProviderEvent::Typing { chat_id, user_name });
+                            }
+                            tl::enums::Update::ChatUserTyping(u) => {
+                                // Legacy group: participant name resolution not attempted;
+                                // chat_name_cache is keyed by chat id, not participant id.
+                                let chat_id = peer_id_to_chat_id(u.chat_id);
+                                let _ = tx.send(ProviderEvent::Typing {
+                                    chat_id,
+                                    user_name: "someone".to_string(),
+                                });
+                            }
+                            tl::enums::Update::ChannelUserTyping(u) => {
+                                let chat_id = peer_id_to_chat_id(u.channel_id);
+                                let _ = tx.send(ProviderEvent::Typing {
+                                    chat_id,
+                                    user_name: "someone".to_string(),
+                                });
+                            }
+                            _ => {}
+                        }
+                        continue;
+                    }
+
+                    // Message path (unchanged) — only NewMessage and MessageEdited reach here.
+                    let (msg, is_edit) = match update {
+                        grammers_client::update::Update::NewMessage(m) => (m, false),
+                        grammers_client::update::Update::MessageEdited(m) => (m, true),
+                        _ => continue,
+                    };
+
+                    let chat_id = msg
+                        .peer_id()
+                        .bot_api_dialog_id()
+                        .map(peer_id_to_chat_id)
+                        .unwrap_or_else(|| "tg-unknown".to_string());
+
+                    // Re-fetch the message by ID to get the full text.
+                    let full_msg: Option<grammers_client::message::Message> =
+                        if let Some(peer_ref) = peer_cache.get(&chat_id) {
+                            match client.get_messages_by_id(peer_ref, &[msg.id()]).await {
+                                Ok(mut msgs) => msgs.pop().flatten(),
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "get_messages_by_id failed for msg {}: {}; using update payload",
+                                        msg.id(), e
+                                    );
+                                    None
+                                }
+                            }
+                        } else {
+                            None
+                        };
+
+                    let effective_msg: &grammers_client::message::Message =
+                        full_msg.as_ref().unwrap_or(&msg);
+
+                    let fallback = chat_name_cache.get(&chat_id);
+                    if let Some(unified) = grammers_message_to_unified(effective_msg, &chat_id, fallback.as_deref()) {
+                        tracing::debug!(
+                            chat_id = %chat_id,
+                            msg_id = %effective_msg.id(),
+                            sender = %unified.sender,
+                            is_edit = %is_edit,
+                            raw_text = %effective_msg.text(),
+                            "telegram raw message (live update)"
+                        );
+                        if is_edit {
+                            let _ = tx.send(ProviderEvent::MessageUpdated(unified));
+                        } else {
+                            let _ = tx.send(ProviderEvent::NewMessage(unified));
+                        }
+                    }
+                }
+```
+
+- [ ] **Step 4.2: Verify it compiles**
+
+```bash
+cargo check 2>&1 | head -30
+```
+
+Expected: clean compile. The `tl::enums::Update::UserTyping` etc. are all real TL types in the grammers crate. If `tl` is not in scope, check the top of the file for `use grammers_tl_types as tl;` — it should already be there.
+
+> **Troubleshooting:** If `tl::enums::Update::UserTyping` gives "no field `user_id`", the TL field names may differ slightly across grammers versions. Run `cargo doc --open` and search for `UpdateUserTyping` to confirm field names.
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add src/providers/telegram/mod.rs
+git commit -m "feat: handle Telegram typing events via Update::Raw TL downcasting"
+```
+
+---
+
+### Task 5: WhatsApp — handle `Event::ChatPresence`
+
+**Files:**
+- Modify: `src/providers/whatsapp/mod.rs:237-238` (imports in `handle_wa_event`), `428-434` (event match end)
+
+- [ ] **Step 5.1: Add `ChatPresence` to the local imports inside `handle_wa_event`**
+
+The function `handle_wa_event` at line 237–238 has local `use` statements:
+```rust
+    use whatsapp_rust::types::events::Event;
+    use whatsapp_rust::Jid;
+```
+
+Add `ChatPresence` to the block:
+```rust
+    use whatsapp_rust::types::events::{ChatPresence, Event};
+    use whatsapp_rust::Jid;
+```
+
+- [ ] **Step 5.2: Add the `ChatPresence` match arm**
+
+The current match ends at lines 428–435:
+```rust
+        Event::OfflineSyncCompleted(_) => {
+            tracing::info!("WhatsApp offline sync completed");
+            let _ = tx.send(ProviderEvent::SyncCompleted);
+        }
+        _ => {
+            tracing::trace!("Unhandled WhatsApp event");
+        }
+    }
+```
+
+Before the wildcard `_ =>` arm, insert:
+```rust
+        Event::ChatPresence(update) => {
+            if update.state == ChatPresence::Composing {
+                let chat_id = format!("wa-{}", update.source.chat);
+                // Use source.sender (not source.chat) — they differ in group chats
+                // where source.chat is the group JID and source.sender is the typer.
+                let user_name = update.source.sender.user.clone();
+                tracing::debug!(chat_id = %chat_id, user_name = %user_name, "WhatsApp typing");
+                let _ = tx.send(ProviderEvent::Typing { chat_id, user_name });
+            }
+        }
+```
+
+- [ ] **Step 5.3: Verify it compiles**
+
+```bash
+cargo check 2>&1 | head -30
+```
+
+Expected: clean compile.
+
+> **Troubleshooting:** If `ChatPresence` is not found at that path, run:
+> ```bash
+> cargo doc 2>/dev/null && grep -r "ChatPresence" target/doc/whatsapp_rust/ 2>/dev/null | head -5
+> ```
+> or search the whatsapp-rust source:
+> ```bash
+> grep -r "ChatPresence" ~/.cargo/git/checkouts/whatsapp-rust-*/*/wacore/src/ 2>/dev/null | head -10
+> ```
+> Adjust the import path accordingly.
+
+> **Troubleshooting:** If `update.source.sender.user` doesn't exist, check the `MessageSource` type in the whatsapp-rust crate. The field names for the JID parts may differ (e.g. `.user_part()` method vs `.user` field).
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add src/providers/whatsapp/mod.rs
+git commit -m "feat: handle WhatsApp ChatPresence typing events"
+```
+
+---
+
+## Chunk 3: TUI rendering
+
+### Task 6: Update chat list widget to show typing indicator
+
+**Files:**
+- Modify: `src/tui/widgets/chat_list.rs` (full file)
+- Modify: `src/tui/render.rs:56-63` (call site)
+
+**Context:** `make_item(chat, is_selected)` builds the `ListItem` for each chat row. We'll add an optional `typing_blink: Option<bool>` parameter — `None` = not typing, `Some(phase)` = show the pulsing dot. The `render_chat_list` function gets two new parameters.
+
+- [ ] **Step 6.1: Add imports to `chat_list.rs`**
+
+At the top of `src/tui/widgets/chat_list.rs`, the current imports end at line 10:
+```rust
+use crate::tui::app_state::{ActivePanel, InputMode};
+```
+
+Change to:
+```rust
+use std::collections::HashMap;
+
+use crate::tui::app_state::{ActivePanel, InputMode, TypingInfo};
+```
+
+- [ ] **Step 6.2: Update `make_item` signature and body**
+
+Change the `make_item` signature from:
+```rust
+fn make_item(chat: &UnifiedChat, is_selected: bool) -> ListItem<'static> {
+```
+to:
+```rust
+fn make_item(chat: &UnifiedChat, is_selected: bool, typing_blink: Option<bool>) -> ListItem<'static> {
+```
+
+Inside `make_item`, find the `spans` vec that currently ends with:
+```rust
+    let spans = vec![
+        Span::raw(selector),
+        Span::styled(pin_tag.to_string(), Style::default().fg(Color::Yellow)),
+        platform_span,
+        emoji_span,
+        Span::styled(name, Style::default().fg(name_color)),
+        Span::styled(unread, Style::default().fg(unread_color)),
+    ];
+```
+
+Replace with:
+```rust
+    let spans = if let Some(phase) = typing_blink {
+        let dot_color = if phase { Color::Green } else { Color::DarkGray };
+        vec![
+            Span::raw(selector),
+            Span::styled(pin_tag.to_string(), Style::default().fg(Color::Yellow)),
+            platform_span,
+            emoji_span,
+            Span::styled("● ", Style::default().fg(dot_color)),
+            Span::styled(name, Style::default().fg(name_color)),
+            Span::styled(" typing", Style::default().fg(Color::DarkGray)),
+        ]
+    } else {
+        vec![
+            Span::raw(selector),
+            Span::styled(pin_tag.to_string(), Style::default().fg(Color::Yellow)),
+            platform_span,
+            emoji_span,
+            Span::styled(name, Style::default().fg(name_color)),
+            Span::styled(unread, Style::default().fg(unread_color)),
+        ]
+    };
+```
+
+- [ ] **Step 6.3: Update `render_chat_list` signature**
+
+Change the function signature from:
+```rust
+pub fn render_chat_list(
+    f: &mut Frame,
+    area: Rect,
+    chats: &[UnifiedChat],
+    list_state: &mut ListState,
+    active_panel: ActivePanel,
+    input_mode: InputMode,
+) {
+```
+to:
+```rust
+pub fn render_chat_list(
+    f: &mut Frame,
+    area: Rect,
+    chats: &[UnifiedChat],
+    list_state: &mut ListState,
+    active_panel: ActivePanel,
+    input_mode: InputMode,
+    typing_states: &HashMap<String, TypingInfo>,
+    blink_phase: bool,
+) {
+```
+
+- [ ] **Step 6.4: Thread typing info into `make_item` call sites**
+
+There are three places in `render_chat_list` that call `make_item`. Update each one:
+
+**Site 1** — no-pinned-chats path (line ~121):
+```rust
+        let items: Vec<ListItem> = chats
+            .iter()
+            .enumerate()
+            .map(|(i, chat)| make_item(chat, i == selected))
+            .collect();
+```
+→
+```rust
+        let items: Vec<ListItem> = chats
+            .iter()
+            .enumerate()
+            .map(|(i, chat)| {
+                let blink = typing_states.get(&chat.id).map(|_| blink_phase);
+                make_item(chat, i == selected, blink)
+            })
+            .collect();
+```
+
+**Site 2** — pinned section (line ~140):
+```rust
+    let pinned_items: Vec<ListItem> = chats
+        .iter()
+        .filter(|c| c.is_pinned)
+        .enumerate()
+        .map(|(i, chat)| make_item(chat, selected < pinned_count && i == selected))
+        .collect();
+```
+→
+```rust
+    let pinned_items: Vec<ListItem> = chats
+        .iter()
+        .filter(|c| c.is_pinned)
+        .enumerate()
+        .map(|(i, chat)| {
+            let blink = typing_states.get(&chat.id).map(|_| blink_phase);
+            make_item(chat, selected < pinned_count && i == selected, blink)
+        })
+        .collect();
+```
+
+**Site 3** — unpinned section (line ~155):
+```rust
+    let unpinned_items: Vec<ListItem> = chats
+        .iter()
+        .filter(|c| !c.is_pinned)
+        .enumerate()
+        .map(|(i, chat)| {
+            make_item(
+                chat,
+                selected >= pinned_count && i == selected - pinned_count,
+            )
+        })
+        .collect();
+```
+→
+```rust
+    let unpinned_items: Vec<ListItem> = chats
+        .iter()
+        .filter(|c| !c.is_pinned)
+        .enumerate()
+        .map(|(i, chat)| {
+            let blink = typing_states.get(&chat.id).map(|_| blink_phase);
+            make_item(
+                chat,
+                selected >= pinned_count && i == selected - pinned_count,
+                blink,
+            )
+        })
+        .collect();
+```
+
+- [ ] **Step 6.5: Update the call site in `render.rs`**
+
+In `src/tui/render.rs`, the call at lines 56–63:
+```rust
+    chat_list::render_chat_list(
+        f,
+        chat_list_area,
+        &state.chats,
+        &mut state.chat_list_state,
+        state.active_panel,
+        state.input_mode,
+    );
+```
+→
+```rust
+    chat_list::render_chat_list(
+        f,
+        chat_list_area,
+        &state.chats,
+        &mut state.chat_list_state,
+        state.active_panel,
+        state.input_mode,
+        &state.typing_states,
+        state.blink_phase,
+    );
+```
+
+- [ ] **Step 6.6: Verify full compile**
+
+```bash
+cargo check 2>&1
+```
+
+Expected: zero errors.
+
+- [ ] **Step 6.7: Run all tests**
+
+```bash
+cargo test 2>&1 | tail -20
+```
+
+Expected: all tests pass (no regressions).
+
+- [ ] **Step 6.8: Commit**
+
+```bash
+git add src/tui/widgets/chat_list.rs src/tui/render.rs
+git commit -m "feat: render typing indicator in chat list with pulsing green dot"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step F.1: Full build**
+
+```bash
+cargo build 2>&1 | tail -10
+```
+
+Expected: compiles with zero errors.
+
+- [ ] **Step F.2: Smoke test — Telegram typing**
+
+1. Run the app: `cargo run`
+2. Open a Telegram chat with a contact
+3. Ask the contact to type something (or type on another device in the same chat)
+4. Observe: a pulsing `●` dot appears next to the chat name in the left panel within a second
+5. Stop typing: indicator disappears within 5 seconds
+
+- [ ] **Step F.3: Smoke test — WhatsApp typing**
+
+1. Open a WhatsApp chat with a contact
+2. Have the contact start typing
+3. Observe: same pulsing dot + "typing" label in chat list
+4. Stop typing: disappears within 5 seconds
+
+- [ ] **Step F.4: Final commit**
+
+```bash
+git add -p  # review any uncommitted changes
+git commit -m "chore: typing indicator feature complete"
+```

--- a/docs/superpowers/specs/2026-03-16-typing-indicator-design.md
+++ b/docs/superpowers/specs/2026-03-16-typing-indicator-design.md
@@ -19,24 +19,31 @@ Add a "typing indicator" to the chat list panel, similar to Telegram's "...typin
 
 ### 1. Data Model
 
-New struct and fields added to `tui/app_state.rs`:
+New struct added, and new fields on existing structs:
+
+**`tui/app_state.rs`** — add `TypingInfo` struct and two fields on `AppState`:
 
 ```rust
 pub struct TypingInfo {
     pub user_name: String,
     pub expires_at: Instant,
 }
-```
 
-New fields on `AppState`:
-
-```rust
-pub typing_states: HashMap<ChatId, TypingInfo>,
+// in AppState:
+pub typing_states: HashMap<String, TypingInfo>,  // keyed by chat id (String)
 pub blink_phase: bool,
 ```
 
-- `typing_states`: keyed by `ChatId`, holds the typer's name and expiry timestamp
-- `blink_phase`: toggled every 2 ticks (~500ms) to drive the green↔gray pulse
+**`app.rs` (`App` struct)** — add one new field:
+
+```rust
+pub tick_count: u64,   // new field; incremented on every AppEvent::Tick
+```
+
+`blink_phase` lives on `AppState` (accessible to the render path).
+`tick_count` lives on `App` (alongside `schedule_status_ticks`, which follows the same pattern).
+
+Note: chat IDs throughout this codebase are plain `String` values (e.g. `UnifiedChat.id`, `UnifiedMessage.chat_id`). There is no `ChatId` newtype.
 
 ### 2. ProviderEvent
 
@@ -45,7 +52,7 @@ One new variant in `core/provider.rs`:
 ```rust
 pub enum ProviderEvent {
     // ... existing variants unchanged ...
-    Typing { chat_id: ChatId, user_name: String },
+    Typing { chat_id: String, user_name: String },
 }
 ```
 
@@ -55,23 +62,87 @@ No changes to the `MessagingProvider` trait or `MessageRouter`.
 
 File: `src/providers/telegram/mod.rs`
 
-In the existing `stream_updates()` loop, add a match arm:
+The grammers library does **not** expose a first-class `Update::UserTyping` variant. Typing updates arrive via `Update::Raw(raw)`, where `raw.raw` is a `tl::enums::Update`. There are three relevant TL update types that must all be handled:
+
+- `tl::enums::Update::UserTyping(u)` — private chats; `u.user_id` is the typer; chat ID is derived from the peer user
+- `tl::enums::Update::ChatUserTyping(u)` — legacy groups; `u.chat_id` is the chat; `u.from_id` is the typer peer
+- `tl::enums::Update::ChannelUserTyping(u)` — supergroups/channels; `u.channel_id` is the chat; `u.from_id` is the typer peer
+
+**The existing update loop must be restructured.** The current loop uses a binding pattern that silently drops all non-message updates:
 
 ```rust
-Update::UserTyping(typing) => {
-    let chat_id = /* derive from typing.peer */;
-    let user_name = /* look up from chat_name_cache */;
-    let _ = event_tx.send(ProviderEvent::Typing { chat_id, user_name });
-}
+// BEFORE (current code — drops everything except NewMessage/MessageEdited):
+let (msg, is_edit) = match update {
+    Update::NewMessage(m) => (m, false),
+    Update::MessageEdited(m) => (m, true),
+    _ => continue,  // <-- this fires for Raw, dropping typing updates
+};
 ```
 
-Grammers exposes both `updateUserTyping` (private chats) and `updateChatUserTyping` (groups) via `Update::UserTyping`. The `peer` field identifies the chat; `chat_name_cache` (already in scope) provides the display name.
+This must be refactored so that `Update::Raw` is handled before the wildcard `continue`. The recommended restructure:
+
+```rust
+// AFTER — handle Raw typing events, then process message updates:
+if let Update::Raw(raw) = &update {
+    match &raw.raw {
+        tl::enums::Update::UserTyping(u) => {
+            let chat_id = format!("tg-{}", u.user_id);
+            let user_name = chat_name_cache
+                .get(&chat_id)
+                .cloned()
+                .unwrap_or_else(|| format!("User {}", u.user_id));
+            let _ = event_tx.send(ProviderEvent::Typing { chat_id, user_name });
+        }
+        tl::enums::Update::ChatUserTyping(u) => {
+            let chat_id = format!("tg-{}", u.chat_id);
+            let _ = event_tx.send(ProviderEvent::Typing {
+                chat_id,
+                user_name: "someone".to_string(),
+            });
+        }
+        tl::enums::Update::ChannelUserTyping(u) => {
+            let chat_id = format!("tg-{}", u.channel_id);
+            let _ = event_tx.send(ProviderEvent::Typing {
+                chat_id,
+                user_name: "someone".to_string(),
+            });
+        }
+        _ => {}
+    }
+    continue;  // Raw updates are never messages; skip message-binding below
+}
+
+// existing message-binding path (unchanged):
+let (msg, is_edit) = match update {
+    Update::NewMessage(m) => (m, false),
+    Update::MessageEdited(m) => (m, true),
+    _ => continue,
+};
+```
+
+**Note on group user names:** `chat_name_cache` is keyed by dialog/chat ID, not by participant user ID. For group typing events, resolving the participant's name would require a separate `client.get_entity()` call (async, could block the update loop) or a dedicated user name cache. For the initial implementation, group typers display as "someone" or a generic label. A user name cache can be layered on top later.
 
 ### 4. WhatsApp Provider
 
 File: `src/providers/whatsapp/mod.rs`
 
-Handle the typing presence event from `whatsapp-rust` (exact event name to be confirmed during implementation), extract `chat_id` and sender display name, send `ProviderEvent::Typing`.
+The `whatsapp-rust` library emits `Event::ChatPresence(ChatPresenceUpdate)` for typing events. `ChatPresenceUpdate` has:
+- `.state: ChatPresence` — `ChatPresence::Composing` (typing) or `ChatPresence::Paused` (stopped)
+- `.source` — the sender JID (contains the chat JID and participant info)
+
+In the existing `handle_wa_event` match block (already switches on `Event`), add:
+
+```rust
+Event::ChatPresence(update) => {
+    if update.state == ChatPresence::Composing {
+        let chat_id = format!("wa-{}", update.source.chat);
+        // Use source.sender (not source.chat) — they differ in group chats where
+        // source.chat is the group JID and source.sender is the typing participant.
+        let user_name = update.source.sender.user.clone();
+        let _ = event_tx.send(ProviderEvent::Typing { chat_id, user_name });
+    }
+}
+```
 
 ### 5. AppState — Tick Handler
 
@@ -80,6 +151,8 @@ File: `src/app.rs`
 **On `AppEvent::Tick`:**
 
 ```rust
+self.tick_count += 1;
+
 // 1. Expire stale indicators
 let now = Instant::now();
 self.state.typing_states.retain(|_, v| v.expires_at > now);
@@ -89,8 +162,6 @@ if self.tick_count % 2 == 0 {
     self.state.blink_phase = !self.state.blink_phase;
 }
 ```
-
-`tick_count` is the existing field already used for AI debounce — no new field needed.
 
 **On `ProviderEvent::Typing`:**
 
@@ -109,11 +180,32 @@ Each new typing event resets the 5-second window, keeping the indicator alive du
 
 File: `src/tui/widgets/chat_list.rs`
 
-When rendering each chat row, check `typing_states`:
+The current signature of `render_chat_list` does not include `AppState`. Two new parameters are added:
 
 ```rust
-if let Some(typing) = app_state.typing_states.get(&chat.id) {
-    let dot_color = if app_state.blink_phase {
+pub fn render_chat_list(
+    f: &mut Frame,
+    area: Rect,
+    chats: &[UnifiedChat],
+    list_state: &mut ListState,
+    active_panel: ActivePanel,
+    input_mode: InputMode,
+    typing_states: &HashMap<String, TypingInfo>,  // new
+    blink_phase: bool,                             // new
+)
+```
+
+The call site in `src/tui/render.rs` is updated to pass `&app_state.typing_states` and `app_state.blink_phase`.
+
+**Required `use` additions:**
+- `src/tui/widgets/chat_list.rs`: add `use std::collections::HashMap;` and `use crate::tui::app_state::TypingInfo;`
+- `src/tui/render.rs`: no new imports needed — `TypingInfo` is not referenced by name at the call site
+
+When rendering each chat row:
+
+```rust
+if let Some(typing) = typing_states.get(&chat.id) {
+    let dot_color = if blink_phase {
         Color::Green
     } else {
         Color::DarkGray
@@ -122,43 +214,46 @@ if let Some(typing) = app_state.typing_states.get(&chat.id) {
     line.push(Span::styled(&chat.name, name_style));
     line.push(Span::styled(" typing", Style::default().fg(Color::DarkGray)));
 } else {
-    // existing render path
+    // existing render path unchanged
 }
 ```
 
-The dot pulses green↔gray. The "typing" label is always dim gray. The chat name retains its normal style (highlighted when selected).
+The dot pulses green↔gray. The "typing" label stays dim gray. The chat name retains its normal style (highlighted when selected).
 
 ## Data Flow
 
 ```
-Platform event (Telegram/WhatsApp)
-  → Provider fires ProviderEvent::Typing { chat_id, user_name }
-  → MessageRouter delivers to AppState
+Platform event (Telegram via Update::Raw TL typing / WhatsApp via Event::ChatPresence)
+  → Provider fires ProviderEvent::Typing { chat_id: String, user_name: String }
+  → MessageRouter delivers to AppState handler in app.rs
   → typing_states.insert(chat_id, TypingInfo { expires_at: now + 5s })
 
 AppEvent::Tick (every 250ms)
-  → typing_states.retain(|_, v| v.expires_at > now)   // expire old
-  → blink_phase toggled every 2 ticks                  // drive animation
+  → tick_count += 1
+  → typing_states.retain(|_, v| v.expires_at > now)   // expire stale entries
+  → blink_phase toggled every 2 ticks (~500ms)          // drive animation
 
 AppEvent::Render (every 33ms)
-  → chat_list widget reads typing_states + blink_phase
-  → renders ● (green or gray) + "typing" label inline
+  → render_chat_list reads typing_states + blink_phase
+  → renders ● (green or gray) + "typing" label inline per chat row
 ```
 
 ## Files Changed
 
 | File | Change |
 |------|--------|
-| `src/core/provider.rs` | Add `ProviderEvent::Typing` variant |
-| `src/tui/app_state.rs` | Add `TypingInfo` struct, `typing_states` and `blink_phase` fields |
-| `src/app.rs` | Handle `ProviderEvent::Typing`; expire + blink logic on tick |
-| `src/providers/telegram/mod.rs` | Handle `Update::UserTyping` in update loop |
-| `src/providers/whatsapp/mod.rs` | Handle typing presence event |
-| `src/tui/widgets/chat_list.rs` | Render typing indicator in chat rows |
+| `src/core/provider.rs` | Add `ProviderEvent::Typing { chat_id: String, user_name: String }` variant |
+| `src/tui/app_state.rs` | Add `TypingInfo` struct; add `typing_states: HashMap<String, TypingInfo>` and `blink_phase: bool` to `AppState` |
+| `src/app.rs` | Add `tick_count: u64` to `App`; handle `ProviderEvent::Typing`; expire + blink logic on tick |
+| `src/providers/telegram/mod.rs` | Match `Update::Raw` and downcast to three TL typing update types |
+| `src/providers/whatsapp/mod.rs` | Handle `Event::ChatPresence` with `ChatPresence::Composing` state |
+| `src/tui/widgets/chat_list.rs` | Add `typing_states` and `blink_phase` params; render indicator per chat row |
+| `src/tui/render.rs` | Update `render_chat_list` call site to pass new parameters |
 
 ## Out of Scope
 
 - Mock provider typing simulation (can be added later for testing)
 - Group chat: multiple people typing simultaneously (show first typer only for now)
+- Group chat participant name resolution (show generic label for initial implementation; user name cache can follow)
 - "Stopped typing" explicit event (timeout handles this)
 - Indicator in the message view area (placement decision: chat list only)

--- a/docs/superpowers/specs/2026-03-16-typing-indicator-design.md
+++ b/docs/superpowers/specs/2026-03-16-typing-indicator-design.md
@@ -29,15 +29,26 @@ pub struct TypingInfo {
     pub expires_at: Instant,
 }
 
-// in AppState:
+// in AppState struct:
 pub typing_states: HashMap<String, TypingInfo>,  // keyed by chat id (String)
 pub blink_phase: bool,
+```
+
+Initialize in `AppState::new()`:
+```rust
+typing_states: HashMap::new(),
+blink_phase: false,
 ```
 
 **`app.rs` (`App` struct)** — add one new field:
 
 ```rust
-pub tick_count: u64,   // new field; incremented on every AppEvent::Tick
+tick_count: u64,   // new field; alongside schedule_status_ticks
+```
+
+Initialize in `App::new()` (in the `Self { ... }` block, alongside `schedule_status_ticks: 0`):
+```rust
+tick_count: 0,
 ```
 
 `blink_phase` lives on `AppState` (accessible to the render path).
@@ -79,46 +90,52 @@ let (msg, is_edit) = match update {
 };
 ```
 
-This must be refactored so that `Update::Raw` is handled before the wildcard `continue`. The recommended restructure:
+This must be refactored so that `Update::Raw` is handled before the wildcard `continue`. The full restructured `Ok(update) =>` arm (inside `match update_stream.next().await`):
 
 ```rust
-// AFTER — handle Raw typing events, then process message updates:
-if let Update::Raw(raw) = &update {
-    match &raw.raw {
-        tl::enums::Update::UserTyping(u) => {
-            let chat_id = format!("tg-{}", u.user_id);
-            let user_name = chat_name_cache
-                .get(&chat_id)
-                .cloned()
-                .unwrap_or_else(|| format!("User {}", u.user_id));
-            let _ = event_tx.send(ProviderEvent::Typing { chat_id, user_name });
+Ok(update) => {
+    // Handle Raw typing updates via borrow — update is still owned below.
+    // The `continue` inside exits the loop iteration before the message path.
+    if let grammers_client::update::Update::Raw(raw) = &update {
+        match &raw.raw {
+            tl::enums::Update::UserTyping(u) => {
+                let chat_id = peer_id_to_chat_id(u.user_id);
+                let user_name = chat_name_cache
+                    .get(&chat_id)
+                    .cloned()
+                    .unwrap_or_else(|| format!("User {}", u.user_id));
+                let _ = event_tx.send(ProviderEvent::Typing { chat_id, user_name });
+            }
+            tl::enums::Update::ChatUserTyping(u) => {
+                let chat_id = peer_id_to_chat_id(u.chat_id);
+                let _ = event_tx.send(ProviderEvent::Typing {
+                    chat_id,
+                    user_name: "someone".to_string(),
+                });
+            }
+            tl::enums::Update::ChannelUserTyping(u) => {
+                let chat_id = peer_id_to_chat_id(u.channel_id);
+                let _ = event_tx.send(ProviderEvent::Typing {
+                    chat_id,
+                    user_name: "someone".to_string(),
+                });
+            }
+            _ => {}
         }
-        tl::enums::Update::ChatUserTyping(u) => {
-            let chat_id = format!("tg-{}", u.chat_id);
-            let _ = event_tx.send(ProviderEvent::Typing {
-                chat_id,
-                user_name: "someone".to_string(),
-            });
-        }
-        tl::enums::Update::ChannelUserTyping(u) => {
-            let chat_id = format!("tg-{}", u.channel_id);
-            let _ = event_tx.send(ProviderEvent::Typing {
-                chat_id,
-                user_name: "someone".to_string(),
-            });
-        }
-        _ => {}
+        continue;  // Raw updates are never messages; skip message-binding below
     }
-    continue;  // Raw updates are never messages; skip message-binding below
-}
 
-// existing message-binding path (unchanged):
-let (msg, is_edit) = match update {
-    Update::NewMessage(m) => (m, false),
-    Update::MessageEdited(m) => (m, true),
-    _ => continue,
-};
+    // existing message-binding path (unchanged):
+    let (msg, is_edit) = match update {
+        grammers_client::update::Update::NewMessage(m) => (m, false),
+        grammers_client::update::Update::MessageEdited(m) => (m, true),
+        _ => continue,
+    };
+    // ... rest of existing loop body unchanged ...
+}
 ```
+
+`peer_id_to_chat_id` (already imported via `use convert::peer_id_to_chat_id`) produces the canonical `"tg-{id}"` key format used throughout the codebase — use it instead of `format!("tg-{}", ...)` directly.
 
 **Note on group user names:** `chat_name_cache` is keyed by dialog/chat ID, not by participant user ID. For group typing events, resolving the participant's name would require a separate `client.get_entity()` call (async, could block the update loop) or a dedicated user name cache. For the initial implementation, group typers display as "someone" or a generic label. A user name cache can be layered on top later.
 
@@ -143,6 +160,12 @@ Event::ChatPresence(update) => {
     }
 }
 ```
+
+**Required `use` additions in `src/providers/whatsapp/mod.rs`:**
+```rust
+use whatsapp_rust::types::events::ChatPresence;
+```
+(`ChatPresenceUpdate` arrives as the inner type of `Event::ChatPresence`; `ChatPresence` is the enum for `.state`.)
 
 ### 5. AppState — Tick Handler
 
@@ -240,9 +263,11 @@ AppEvent::Render (every 33ms)
 
 ## Files Changed
 
+**Implementation order matters:** `src/core/provider.rs` must be modified first — all other files that reference `ProviderEvent::Typing` will not compile until the new variant exists.
+
 | File | Change |
 |------|--------|
-| `src/core/provider.rs` | Add `ProviderEvent::Typing { chat_id: String, user_name: String }` variant |
+| `src/core/provider.rs` | Add `ProviderEvent::Typing { chat_id: String, user_name: String }` variant — **do this first** |
 | `src/tui/app_state.rs` | Add `TypingInfo` struct; add `typing_states: HashMap<String, TypingInfo>` and `blink_phase: bool` to `AppState` |
 | `src/app.rs` | Add `tick_count: u64` to `App`; handle `ProviderEvent::Typing`; expire + blink logic on tick |
 | `src/providers/telegram/mod.rs` | Match `Update::Raw` and downcast to three TL typing update types |

--- a/docs/superpowers/specs/2026-03-16-typing-indicator-design.md
+++ b/docs/superpowers/specs/2026-03-16-typing-indicator-design.md
@@ -1,0 +1,164 @@
+# Typing Indicator — Design Spec
+
+**Date:** 2026-03-16
+**Status:** Approved
+
+## Overview
+
+Add a "typing indicator" to the chat list panel, similar to Telegram's "...typing" dynamic indicator. When a contact is typing in a chat, a pulsing green dot and "typing" label appear next to their chat entry in the left panel. The indicator disappears automatically 5 seconds after the last typing event.
+
+## Requirements
+
+- **Platforms:** Telegram and WhatsApp
+- **Placement:** Chat list panel (left column), in-line with the chat name
+- **Animation:** Green dot (●) pulses between bright green and dark gray at ~2 Hz
+- **Timeout:** 5 seconds after the last received typing event
+- **Multiple chats:** Each chat tracks its own typing state independently
+
+## Design
+
+### 1. Data Model
+
+New struct and fields added to `tui/app_state.rs`:
+
+```rust
+pub struct TypingInfo {
+    pub user_name: String,
+    pub expires_at: Instant,
+}
+```
+
+New fields on `AppState`:
+
+```rust
+pub typing_states: HashMap<ChatId, TypingInfo>,
+pub blink_phase: bool,
+```
+
+- `typing_states`: keyed by `ChatId`, holds the typer's name and expiry timestamp
+- `blink_phase`: toggled every 2 ticks (~500ms) to drive the green↔gray pulse
+
+### 2. ProviderEvent
+
+One new variant in `core/provider.rs`:
+
+```rust
+pub enum ProviderEvent {
+    // ... existing variants unchanged ...
+    Typing { chat_id: ChatId, user_name: String },
+}
+```
+
+No changes to the `MessagingProvider` trait or `MessageRouter`.
+
+### 3. Telegram Provider
+
+File: `src/providers/telegram/mod.rs`
+
+In the existing `stream_updates()` loop, add a match arm:
+
+```rust
+Update::UserTyping(typing) => {
+    let chat_id = /* derive from typing.peer */;
+    let user_name = /* look up from chat_name_cache */;
+    let _ = event_tx.send(ProviderEvent::Typing { chat_id, user_name });
+}
+```
+
+Grammers exposes both `updateUserTyping` (private chats) and `updateChatUserTyping` (groups) via `Update::UserTyping`. The `peer` field identifies the chat; `chat_name_cache` (already in scope) provides the display name.
+
+### 4. WhatsApp Provider
+
+File: `src/providers/whatsapp/mod.rs`
+
+Handle the typing presence event from `whatsapp-rust` (exact event name to be confirmed during implementation), extract `chat_id` and sender display name, send `ProviderEvent::Typing`.
+
+### 5. AppState — Tick Handler
+
+File: `src/app.rs`
+
+**On `AppEvent::Tick`:**
+
+```rust
+// 1. Expire stale indicators
+let now = Instant::now();
+self.state.typing_states.retain(|_, v| v.expires_at > now);
+
+// 2. Advance blink phase every 2 ticks (~500ms)
+if self.tick_count % 2 == 0 {
+    self.state.blink_phase = !self.state.blink_phase;
+}
+```
+
+`tick_count` is the existing field already used for AI debounce — no new field needed.
+
+**On `ProviderEvent::Typing`:**
+
+```rust
+ProviderEvent::Typing { chat_id, user_name } => {
+    self.state.typing_states.insert(chat_id, TypingInfo {
+        user_name,
+        expires_at: Instant::now() + Duration::from_secs(5),
+    });
+}
+```
+
+Each new typing event resets the 5-second window, keeping the indicator alive during continuous typing.
+
+### 6. Chat List Widget
+
+File: `src/tui/widgets/chat_list.rs`
+
+When rendering each chat row, check `typing_states`:
+
+```rust
+if let Some(typing) = app_state.typing_states.get(&chat.id) {
+    let dot_color = if app_state.blink_phase {
+        Color::Green
+    } else {
+        Color::DarkGray
+    };
+    line.push(Span::styled("● ", Style::default().fg(dot_color)));
+    line.push(Span::styled(&chat.name, name_style));
+    line.push(Span::styled(" typing", Style::default().fg(Color::DarkGray)));
+} else {
+    // existing render path
+}
+```
+
+The dot pulses green↔gray. The "typing" label is always dim gray. The chat name retains its normal style (highlighted when selected).
+
+## Data Flow
+
+```
+Platform event (Telegram/WhatsApp)
+  → Provider fires ProviderEvent::Typing { chat_id, user_name }
+  → MessageRouter delivers to AppState
+  → typing_states.insert(chat_id, TypingInfo { expires_at: now + 5s })
+
+AppEvent::Tick (every 250ms)
+  → typing_states.retain(|_, v| v.expires_at > now)   // expire old
+  → blink_phase toggled every 2 ticks                  // drive animation
+
+AppEvent::Render (every 33ms)
+  → chat_list widget reads typing_states + blink_phase
+  → renders ● (green or gray) + "typing" label inline
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/core/provider.rs` | Add `ProviderEvent::Typing` variant |
+| `src/tui/app_state.rs` | Add `TypingInfo` struct, `typing_states` and `blink_phase` fields |
+| `src/app.rs` | Handle `ProviderEvent::Typing`; expire + blink logic on tick |
+| `src/providers/telegram/mod.rs` | Handle `Update::UserTyping` in update loop |
+| `src/providers/whatsapp/mod.rs` | Handle typing presence event |
+| `src/tui/widgets/chat_list.rs` | Render typing indicator in chat rows |
+
+## Out of Scope
+
+- Mock provider typing simulation (can be added later for testing)
+- Group chat: multiple people typing simultaneously (show first typer only for now)
+- "Stopped typing" explicit event (timeout handles this)
+- Indicator in the message view area (placement decision: chat list only)

--- a/docs/superpowers/specs/2026-03-16-typing-indicator-design.md
+++ b/docs/superpowers/specs/2026-03-16-typing-indicator-design.md
@@ -163,9 +163,9 @@ Event::ChatPresence(update) => {
 
 **Required `use` additions in `src/providers/whatsapp/mod.rs`:**
 ```rust
-use whatsapp_rust::types::events::ChatPresence;
+use whatsapp_rust::types::presence::ChatPresence;
 ```
-(`ChatPresenceUpdate` arrives as the inner type of `Event::ChatPresence`; `ChatPresence` is the enum for `.state`.)
+(`ChatPresenceUpdate` arrives as the inner type of `Event::ChatPresence`; `ChatPresence` is the enum for `.state`. Note: the type lives in `types::presence`, not `types::events`.)
 
 ### 5. AppState — Tick Handler
 

--- a/docs/superpowers/specs/2026-03-16-typing-indicator-running-light-design.md
+++ b/docs/superpowers/specs/2026-03-16-typing-indicator-running-light-design.md
@@ -109,6 +109,11 @@ assert_eq!(state.blink_phase, 0);
 
 No other test changes required. All 82 existing tests must still pass.
 
+## Notes
+
+- **Width:** Each dot is `"● "` (2 chars), so 3 dots = 6 chars total — 4 chars more than before. In narrow panes the chat name may truncate slightly more. Acceptable trade-off.
+- **Doc comment:** Update the `blink_phase` field comment in `app_state.rs` from `"green↔gray blink animation"` to reflect the 3-phase running-light behaviour.
+
 ## Out of Scope
 
 - Changing the dot character to a larger glyph

--- a/docs/superpowers/specs/2026-03-16-typing-indicator-running-light-design.md
+++ b/docs/superpowers/specs/2026-03-16-typing-indicator-running-light-design.md
@@ -113,6 +113,7 @@ No other test changes required. All 82 existing tests must still pass.
 
 - **Width:** Each dot is `"● "` (2 chars), so 3 dots = 6 chars total — 4 chars more than before. In narrow panes the chat name may truncate slightly more. Acceptable trade-off.
 - **Doc comment:** Update the `blink_phase` field comment in `app_state.rs` from `"green↔gray blink animation"` to reflect the 3-phase running-light behaviour.
+- **Highlight style fg:** `render_chat_list` must NOT set `.fg(Color::White)` on the highlight style. ratatui applies the highlight style over span-level colors; setting a global `fg` would override the per-dot green color, making the chaser invisible on selected rows. The `▶` selector and blue background are sufficient to communicate selection.
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-03-16-typing-indicator-running-light-design.md
+++ b/docs/superpowers/specs/2026-03-16-typing-indicator-running-light-design.md
@@ -1,0 +1,116 @@
+# Typing Indicator — Running Light Animation
+
+**Date:** 2026-03-16
+**Status:** Approved
+
+## Goal
+
+Replace the current single-dot green↔gray blink with a 3-dot running-light (chaser) animation: three `●` dots rendered inline, with one lit green at a time sweeping left→right.
+
+## Visual
+
+```
+phase=0 → ●○○  Alice  typing
+phase=1 → ○●○  Alice  typing
+phase=2 → ○○●  Alice  typing
+```
+
+- Lit dot: `Color::Green`
+- Dim dots: `Color::DarkGray`
+- Character: `●` (U+25CF, same as current)
+- Cycle time: 2 ticks per phase step × 250ms tick = 500ms/step → ~1.5s full sweep
+
+## Data Model Change
+
+`blink_phase` changes type from `bool` to `u8` with values `0`, `1`, `2`.
+
+**`src/tui/app_state.rs`:**
+```rust
+// before
+pub blink_phase: bool,
+
+// after
+/// Running-light phase: 0=first dot lit, 1=middle, 2=last. Cycles every 2 ticks (~500ms/step).
+pub blink_phase: u8,
+```
+
+Initialization: `blink_phase: 0`
+
+## Tick Handler Change
+
+**`src/app.rs`** — in `handle_tick`, replace the toggle:
+```rust
+// before
+if self.tick_count % 2 == 0 {
+    self.state.blink_phase = !self.state.blink_phase;
+}
+
+// after
+if self.tick_count % 2 == 0 {
+    self.state.blink_phase = (self.state.blink_phase + 1) % 3;
+}
+```
+
+## Widget Change
+
+**`src/tui/widgets/chat_list.rs`:**
+
+`make_item` signature:
+```rust
+// before
+fn make_item(chat: &UnifiedChat, is_selected: bool, typing_blink: Option<bool>) -> ListItem<'static>
+
+// after
+fn make_item(chat: &UnifiedChat, is_selected: bool, typing_blink: Option<u8>) -> ListItem<'static>
+```
+
+Typing branch of `spans` construction:
+```rust
+// before
+Span::styled("● ", Style::default().fg(dot_color)),
+Span::styled(name, ...),
+Span::styled(" typing", ...),
+
+// after — 3 dots, each colored independently
+let dot = |i: u8| {
+    let color = if phase == i { Color::Green } else { Color::DarkGray };
+    Span::styled("● ", Style::default().fg(color))
+};
+// spans:
+dot(0),
+dot(1),
+dot(2),
+Span::styled(name, ...),
+Span::styled(" typing", ...),
+```
+
+`render_chat_list` signature — `blink_phase: bool` → `blink_phase: u8` (parameter type only; the call sites `typing_states.get(&chat.id).map(|_| blink_phase)` are unchanged in structure).
+
+## Call Site Change
+
+**`src/tui/render.rs`** — no change needed. `state.blink_phase` is passed through as-is; the type flows automatically.
+
+The three `make_item` call sites in `chat_list.rs` that compute:
+```rust
+let blink = typing_states.get(&chat.id).map(|_| blink_phase);
+```
+remain structurally identical — the closure is unchanged, the type inference updates automatically.
+
+## Testing
+
+Update the existing unit test in `app_state.rs`:
+```rust
+// before
+assert!(!state.blink_phase);
+
+// after
+assert_eq!(state.blink_phase, 0);
+```
+
+No other test changes required. All 82 existing tests must still pass.
+
+## Out of Scope
+
+- Changing the dot character to a larger glyph
+- Per-chat independent phase offsets
+- Directional reverse sweep (right→left on alternate cycles)

--- a/src/app.rs
+++ b/src/app.rs
@@ -646,6 +646,9 @@ impl App {
                         lid_chat_id
                     );
                 }
+                ProviderEvent::Typing { .. } => {
+                    // TODO: Handle typing indicators (Task 3)
+                }
             }
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -355,7 +355,7 @@ impl App {
         let now = std::time::Instant::now();
         self.state.typing_states.retain(|_, v| v.expires_at > now);
         if self.tick_count % 2 == 0 {
-            self.state.blink_phase = !self.state.blink_phase;
+            self.state.blink_phase = (self.state.blink_phase + 1) % 3;
         }
 
         let events = self.router.poll_events();

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,7 +23,7 @@ use crate::providers::whatsapp::WhatsAppProvider;
 use crate::storage::{AddressBook, Database, ScheduledMessage};
 use tui_textarea::TextArea;
 
-use crate::tui::app_state::{AppState, ChatMenuItem, InputMode, SchedulePromptState, ScheduleListState, SearchState, SettingsKey, SettingsValue};
+use crate::tui::app_state::{AppState, ChatMenuItem, InputMode, SchedulePromptState, ScheduleListState, SearchState, SettingsKey, SettingsValue, TypingInfo};
 use crate::tui::time_parse::{parse_schedule_time, format_local_time};
 use crate::tui::event::{AppEvent, EventHandler};
 use crate::tui::keybindings::{map_key, Action};
@@ -43,6 +43,7 @@ pub struct App {
     db_summary_tx: tokio::sync::mpsc::UnboundedSender<(String, String)>,
     db_summary_rx: tokio::sync::mpsc::UnboundedReceiver<(String, String)>,
     schedule_status_ticks: u8,
+    tick_count: u64,
     telegram_auth_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::providers::telegram::AuthInput>>,
     event_tx: tokio::sync::mpsc::UnboundedSender<AppEvent>,
 }
@@ -93,6 +94,7 @@ impl App {
             db_summary_tx,
             db_summary_rx,
             schedule_status_ticks: 0,
+            tick_count: 0,
             telegram_auth_tx: None,
             event_tx,
         }
@@ -346,6 +348,14 @@ impl App {
             }
         } else {
             self.schedule_status_ticks = 0;
+        }
+
+        // Advance tick counter and drive typing indicator animation
+        self.tick_count += 1;
+        let now = std::time::Instant::now();
+        self.state.typing_states.retain(|_, v| v.expires_at > now);
+        if self.tick_count % 2 == 0 {
+            self.state.blink_phase = !self.state.blink_phase;
         }
 
         let events = self.router.poll_events();
@@ -646,8 +656,11 @@ impl App {
                         lid_chat_id
                     );
                 }
-                ProviderEvent::Typing { .. } => {
-                    // TODO: Handle typing indicators (Task 3)
+                ProviderEvent::Typing { chat_id, user_name } => {
+                    self.state.typing_states.insert(chat_id, TypingInfo {
+                        user_name,
+                        expires_at: std::time::Instant::now() + std::time::Duration::from_secs(5),
+                    });
                 }
             }
         }

--- a/src/core/provider.rs
+++ b/src/core/provider.rs
@@ -30,6 +30,10 @@ pub enum ProviderEvent {
     /// `lid` and `pn` are raw JID strings (no `wa-` prefix).
     /// The app layer should persist this and remove the stale `wa-<lid>` chat entry.
     LidPnMappingDiscovered { lid: String, pn: String },
+    /// A contact in the given chat is currently typing.
+    /// Fires on each typing update from the platform; the TUI expires the
+    /// indicator automatically after 5 seconds without a new event.
+    Typing { chat_id: String, user_name: String },
 }
 
 #[async_trait]

--- a/src/providers/telegram/mod.rs
+++ b/src/providers/telegram/mod.rs
@@ -9,6 +9,7 @@ use futures::future::BoxFuture;
 use grammers_client::client::UpdatesConfiguration;
 use grammers_client::peer::Peer;
 use grammers_client::{Client, SenderPool, SignInError};
+use grammers_client::tl;
 use grammers_session::{Session, SessionData};
 use grammers_session::types::{ChannelKind, DcOption, PeerId, PeerInfo, UpdateState, UpdatesState};
 use serde::{Deserialize, Serialize};
@@ -481,6 +482,40 @@ impl TelegramProvider {
         loop {
             match update_stream.next().await {
                 Ok(update) => {
+                    // Handle Raw typing updates first (borrow avoids moving `update`).
+                    // The `continue` skips the message-processing path below.
+                    if let grammers_client::update::Update::Raw(raw) = &update {
+                        match &raw.raw {
+                            tl::enums::Update::UserTyping(u) => {
+                                // Private chat: chat_id derived from the peer user id
+                                let chat_id = peer_id_to_chat_id(u.user_id);
+                                let user_name = chat_name_cache
+                                    .get(&chat_id)
+                                    .unwrap_or_else(|| format!("User {}", u.user_id));
+                                let _ = tx.send(ProviderEvent::Typing { chat_id, user_name });
+                            }
+                            tl::enums::Update::ChatUserTyping(u) => {
+                                // Legacy group: participant name resolution not attempted;
+                                // chat_name_cache is keyed by chat id, not participant id.
+                                let chat_id = peer_id_to_chat_id(u.chat_id);
+                                let _ = tx.send(ProviderEvent::Typing {
+                                    chat_id,
+                                    user_name: "someone".to_string(),
+                                });
+                            }
+                            tl::enums::Update::ChannelUserTyping(u) => {
+                                let chat_id = peer_id_to_chat_id(u.channel_id);
+                                let _ = tx.send(ProviderEvent::Typing {
+                                    chat_id,
+                                    user_name: "someone".to_string(),
+                                });
+                            }
+                            _ => {}
+                        }
+                        continue;
+                    }
+
+                    // Message path (unchanged) — only NewMessage and MessageEdited reach here.
                     let (msg, is_edit) = match update {
                         grammers_client::update::Update::NewMessage(m) => (m, false),
                         grammers_client::update::Update::MessageEdited(m) => (m, true),
@@ -494,8 +529,6 @@ impl TelegramProvider {
                         .unwrap_or_else(|| "tg-unknown".to_string());
 
                     // Re-fetch the message by ID to get the full text.
-                    // Handles both initial truncation (NewMessage) and streaming
-                    // edits (MessageEdited) from bots building up their response.
                     let full_msg: Option<grammers_client::message::Message> =
                         if let Some(peer_ref) = peer_cache.get(&chat_id) {
                             match client.get_messages_by_id(peer_ref, &[msg.id()]).await {

--- a/src/providers/whatsapp/mod.rs
+++ b/src/providers/whatsapp/mod.rs
@@ -235,6 +235,7 @@ fn handle_wa_event(
     jid_cache: &JidCache,
 ) {
     use whatsapp_rust::types::events::Event;
+    use whatsapp_rust::types::presence::ChatPresence;
     use whatsapp_rust::Jid;
 
     match event {
@@ -428,6 +429,16 @@ fn handle_wa_event(
         Event::OfflineSyncCompleted(_) => {
             tracing::info!("WhatsApp offline sync completed");
             let _ = tx.send(ProviderEvent::SyncCompleted);
+        }
+        Event::ChatPresence(update) => {
+            if update.state == ChatPresence::Composing {
+                let chat_id = format!("wa-{}", update.source.chat);
+                // Use source.sender (not source.chat) — they differ in group chats
+                // where source.chat is the group JID and source.sender is the typer.
+                let user_name = update.source.sender.user.clone();
+                tracing::debug!(chat_id = %chat_id, user_name = %user_name, "WhatsApp typing");
+                let _ = tx.send(ProviderEvent::Typing { chat_id, user_name });
+            }
         }
         _ => {
             tracing::trace!("Unhandled WhatsApp event");

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -595,4 +595,16 @@ mod tests {
         assert!(expired.expires_at <= now, "expired entry should be in the past");
         assert!(active.expires_at > now, "active entry should be in the future");
     }
+
+    #[test]
+    fn test_blink_phase_cycles_0_1_2_0() {
+        // Simulate the tick handler: advance by (phase + 1) % 3 and verify full wrap-around.
+        let mut phase: u8 = 0;
+        phase = (phase + 1) % 3;
+        assert_eq!(phase, 1);
+        phase = (phase + 1) % 3;
+        assert_eq!(phase, 2);
+        phase = (phase + 1) % 3;
+        assert_eq!(phase, 0, "phase should wrap back to 0 after reaching 2");
+    }
 }

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -11,6 +11,9 @@ use crate::storage::ScheduledMessage;
 /// Tracks a contact who is currently typing in a chat.
 #[derive(Debug, Clone)]
 pub struct TypingInfo {
+    /// Stored for future use (e.g. "Alice is typing" in group chats).
+    /// Currently unused by the renderer, which shows a generic " typing" label.
+    #[allow(dead_code)]
     pub user_name: String,
     pub expires_at: Instant,
 }

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -13,7 +13,6 @@ use crate::storage::ScheduledMessage;
 pub struct TypingInfo {
     /// Stored for future use (e.g. "Alice is typing" in group chats).
     /// Currently unused by the renderer, which shows a generic " typing" label.
-    #[allow(dead_code)]
     pub user_name: String,
     pub expires_at: Instant,
 }

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -358,8 +358,8 @@ pub struct AppState {
     pub schedule_status: Option<String>, // flash message for scheduling feedback
     /// Per-chat typing indicators: chat_id → who is typing and when it expires.
     pub typing_states: HashMap<String, TypingInfo>,
-    /// Toggled every 2 ticks (~500ms) to drive the green↔gray blink animation.
-    pub blink_phase: bool,
+    /// Running-light phase: 0=first dot lit, 1=middle, 2=last. Cycles every 2 ticks (~500ms/step).
+    pub blink_phase: u8,
 }
 
 impl AppState {
@@ -395,7 +395,7 @@ impl AppState {
             schedule_list_state: None,
             schedule_status: None,
             typing_states: HashMap::new(),
-            blink_phase: false,
+            blink_phase: 0,
         }
     }
 
@@ -578,7 +578,7 @@ mod tests {
     fn test_app_state_new_has_empty_typing_states() {
         let state = AppState::new();
         assert!(state.typing_states.is_empty());
-        assert!(!state.blink_phase);
+        assert_eq!(state.blink_phase, 0);
     }
 
     #[test]

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -1,9 +1,19 @@
+use std::collections::HashMap;
+use std::time::Instant;
+
 use ratatui::widgets::ListState;
 use tui_textarea::TextArea;
 
 use crate::config::AppConfig;
 use crate::core::types::{Platform, UnifiedChat, UnifiedMessage};
 use crate::storage::ScheduledMessage;
+
+/// Tracks a contact who is currently typing in a chat.
+#[derive(Debug, Clone)]
+pub struct TypingInfo {
+    pub user_name: String,
+    pub expires_at: Instant,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputMode {
@@ -344,6 +354,10 @@ pub struct AppState {
     pub schedule_prompt_state: Option<SchedulePromptState>,
     pub schedule_list_state: Option<ScheduleListState>,
     pub schedule_status: Option<String>, // flash message for scheduling feedback
+    /// Per-chat typing indicators: chat_id → who is typing and when it expires.
+    pub typing_states: HashMap<String, TypingInfo>,
+    /// Toggled every 2 ticks (~500ms) to drive the green↔gray blink animation.
+    pub blink_phase: bool,
 }
 
 impl AppState {
@@ -378,6 +392,8 @@ impl AppState {
             schedule_prompt_state: None,
             schedule_list_state: None,
             schedule_status: None,
+            typing_states: HashMap::new(),
+            blink_phase: false,
         }
     }
 
@@ -548,5 +564,33 @@ impl AppState {
         } else {
             String::new()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_app_state_new_has_empty_typing_states() {
+        let state = AppState::new();
+        assert!(state.typing_states.is_empty());
+        assert!(!state.blink_phase);
+    }
+
+    #[test]
+    fn test_typing_info_expiry() {
+        let expired = TypingInfo {
+            user_name: "Alice".to_string(),
+            expires_at: Instant::now() - Duration::from_secs(1),
+        };
+        let active = TypingInfo {
+            user_name: "Bob".to_string(),
+            expires_at: Instant::now() + Duration::from_secs(5),
+        };
+        let now = Instant::now();
+        assert!(expired.expires_at <= now, "expired entry should be in the past");
+        assert!(active.expires_at > now, "active entry should be in the future");
     }
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -60,6 +60,8 @@ pub fn draw(f: &mut Frame, state: &mut AppState) {
         &mut state.chat_list_state,
         state.active_panel,
         state.input_mode,
+        &state.typing_states,
+        state.blink_phase,
     );
 
     message_view::render_message_view(

--- a/src/tui/widgets/chat_list.rs
+++ b/src/tui/widgets/chat_list.rs
@@ -11,7 +11,7 @@ use ratatui::{
 use crate::core::types::{ChatKind, Platform, UnifiedChat};
 use crate::tui::app_state::{ActivePanel, InputMode, TypingInfo};
 
-fn make_item(chat: &UnifiedChat, is_selected: bool, typing_blink: Option<bool>) -> ListItem<'static> {
+fn make_item(chat: &UnifiedChat, is_selected: bool, typing_blink: Option<u8>) -> ListItem<'static> {
     let unread = if chat.unread_count > 0 {
         format!(" ({})", chat.unread_count)
     } else {
@@ -54,13 +54,18 @@ fn make_item(chat: &UnifiedChat, is_selected: bool, typing_blink: Option<bool>) 
     let emoji_span = Span::raw(format!(" {} ", type_emoji));
 
     let spans = if let Some(phase) = typing_blink {
-        let dot_color = if phase { Color::Green } else { Color::DarkGray };
+        let dot = |i: u8| {
+            let color = if phase == i { Color::Green } else { Color::DarkGray };
+            Span::styled("● ", Style::default().fg(color))
+        };
         vec![
             Span::raw(selector),
             Span::styled(pin_tag.to_string(), Style::default().fg(Color::Yellow)),
             platform_span,
             emoji_span,
-            Span::styled("● ", Style::default().fg(dot_color)),
+            dot(0),
+            dot(1),
+            dot(2),
             Span::styled(name, Style::default().fg(name_color)),
             Span::styled(" typing", Style::default().fg(Color::DarkGray)),
         ]
@@ -85,7 +90,7 @@ pub fn render_chat_list(
     active_panel: ActivePanel,
     input_mode: InputMode,
     typing_states: &HashMap<String, TypingInfo>,
-    blink_phase: bool,
+    blink_phase: u8,
 ) {
     let border_color = if active_panel == ActivePanel::ChatList {
         Color::Cyan
@@ -127,7 +132,6 @@ pub fn render_chat_list(
 
     let highlight = Style::default()
         .bg(Color::Blue)
-        .fg(Color::White)
         .add_modifier(Modifier::BOLD);
 
     if pinned_count == 0 {

--- a/src/tui/widgets/chat_list.rs
+++ b/src/tui/widgets/chat_list.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -7,9 +9,9 @@ use ratatui::{
 };
 
 use crate::core::types::{ChatKind, Platform, UnifiedChat};
-use crate::tui::app_state::{ActivePanel, InputMode};
+use crate::tui::app_state::{ActivePanel, InputMode, TypingInfo};
 
-fn make_item(chat: &UnifiedChat, is_selected: bool) -> ListItem<'static> {
+fn make_item(chat: &UnifiedChat, is_selected: bool, typing_blink: Option<bool>) -> ListItem<'static> {
     let unread = if chat.unread_count > 0 {
         format!(" ({})", chat.unread_count)
     } else {
@@ -51,14 +53,27 @@ fn make_item(chat: &UnifiedChat, is_selected: bool) -> ListItem<'static> {
     };
     let emoji_span = Span::raw(format!(" {} ", type_emoji));
 
-    let spans = vec![
-        Span::raw(selector),
-        Span::styled(pin_tag.to_string(), Style::default().fg(Color::Yellow)),
-        platform_span,
-        emoji_span,
-        Span::styled(name, Style::default().fg(name_color)),
-        Span::styled(unread, Style::default().fg(unread_color)),
-    ];
+    let spans = if let Some(phase) = typing_blink {
+        let dot_color = if phase { Color::Green } else { Color::DarkGray };
+        vec![
+            Span::raw(selector),
+            Span::styled(pin_tag.to_string(), Style::default().fg(Color::Yellow)),
+            platform_span,
+            emoji_span,
+            Span::styled("● ", Style::default().fg(dot_color)),
+            Span::styled(name, Style::default().fg(name_color)),
+            Span::styled(" typing", Style::default().fg(Color::DarkGray)),
+        ]
+    } else {
+        vec![
+            Span::raw(selector),
+            Span::styled(pin_tag.to_string(), Style::default().fg(Color::Yellow)),
+            platform_span,
+            emoji_span,
+            Span::styled(name, Style::default().fg(name_color)),
+            Span::styled(unread, Style::default().fg(unread_color)),
+        ]
+    };
     ListItem::new(Line::from(spans))
 }
 
@@ -69,6 +84,8 @@ pub fn render_chat_list(
     list_state: &mut ListState,
     active_panel: ActivePanel,
     input_mode: InputMode,
+    typing_states: &HashMap<String, TypingInfo>,
+    blink_phase: bool,
 ) {
     let border_color = if active_panel == ActivePanel::ChatList {
         Color::Cyan
@@ -118,7 +135,10 @@ pub fn render_chat_list(
         let items: Vec<ListItem> = chats
             .iter()
             .enumerate()
-            .map(|(i, chat)| make_item(chat, i == selected))
+            .map(|(i, chat)| {
+                let blink = typing_states.get(&chat.id).map(|_| blink_phase);
+                make_item(chat, i == selected, blink)
+            })
             .collect();
         // No highlight_symbol — selector is embedded in item content
         let list = List::new(items).highlight_style(highlight);
@@ -137,7 +157,10 @@ pub fn render_chat_list(
         .iter()
         .filter(|c| c.is_pinned)
         .enumerate()
-        .map(|(i, chat)| make_item(chat, selected < pinned_count && i == selected))
+        .map(|(i, chat)| {
+            let blink = typing_states.get(&chat.id).map(|_| blink_phase);
+            make_item(chat, selected < pinned_count && i == selected, blink)
+        })
         .collect();
     let mut pinned_state = ListState::default();
     if selected < pinned_count {
@@ -152,9 +175,11 @@ pub fn render_chat_list(
         .filter(|c| !c.is_pinned)
         .enumerate()
         .map(|(i, chat)| {
+            let blink = typing_states.get(&chat.id).map(|_| blink_phase);
             make_item(
                 chat,
                 selected >= pinned_count && i == selected - pinned_count,
+                blink,
             )
         })
         .collect();

--- a/src/tui/widgets/chat_list.rs
+++ b/src/tui/widgets/chat_list.rs
@@ -130,6 +130,8 @@ pub fn render_chat_list(
     let selected = list_state.selected().unwrap_or(0);
     let pinned_count = chats.iter().filter(|c| c.is_pinned).count();
 
+    // fg intentionally omitted: letting span-level colors show through (green dot, yellow pin, etc.)
+    // The ▶ selector and blue background together communicate selection without overriding span colors.
     let highlight = Style::default()
         .bg(Color::Blue)
         .add_modifier(Modifier::BOLD);


### PR DESCRIPTION
## Summary

- Add typing indicator in the chat list panel: when a Telegram or WhatsApp contact is typing, a `● ● ●` running-light chaser animates inline with the chat name
- Supports both platforms (Telegram via `Update::Raw` TL downcasting, WhatsApp via `Event::ChatPresence`)
- Indicator auto-expires after 5 seconds with no new typing event
- Animation: one green dot sweeps left→right across three dim dots (~500ms per step, ~1.5s full sweep)
- Highlight style no longer overrides span-level fg colors, so the green dot stays visible on selected (blue-highlighted) rows

## Test Plan

- [ ] Start the app and open a Telegram or WhatsApp chat
- [ ] Have a contact start typing — verify `● ● ●` chaser appears next to the chat name in the left panel
- [ ] Verify the green dot sweeps left→right with a ~500ms step
- [ ] Verify the indicator disappears within 5 seconds after typing stops
- [ ] Select the typing chat (blue highlight) — verify the green dot is still visible
- [ ] `cargo test` — 83 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)