### PR TITLE
feat: btop-inspired UI enhancements — colored bubbles + activity graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.superpowers/

--- a/docs/superpowers/plans/2026-03-17-btop-ui-enhancements.md
+++ b/docs/superpowers/plans/2026-03-17-btop-ui-enhancements.md
@@ -1,0 +1,1007 @@
+# btop UI Enhancements Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two parallel visual enhancements: colored-bar `┃` message bubbles in the message view, and a Braille activity sparkline column in the chat list.
+
+**Architecture:** Feature F rewrites the gutter+header rendering in `message_view.rs` — incoming messages get a left purple `┃`, outgoing messages are right-padded with a cyan `┃` and delivery indicator. Because all lines are pre-wrapped before being pushed into the `Vec<Line>`, the `Wrap` widget option is removed so ratatui does not re-wrap them at render time. Feature C adds a new `activity.rs` storage module that queries 24h message counts per chat, caches them in `AppState`, and renders a 10-char Braille column in `chat_list.rs` when terminal width ≥ 100.
+
+**Tech Stack:** Rust, ratatui 0.29, rusqlite, unicode-width crate (already in Cargo.toml)
+
+**Spec:** `docs/superpowers/specs/2026-03-17-btop-ui-enhancements-design.md`
+
+---
+
+## Chunk 1: Feature F — Colored-Bar Message Bubbles
+
+### Task 1: Delivery status helper
+
+**Files:**
+- Modify: `src/tui/widgets/message_view.rs`
+
+- [ ] **Step 1: Write failing tests for `display_width_of_status`**
+
+Add to the `#[cfg(test)]` block at the bottom of `src/tui/widgets/message_view.rs`:
+
+```rust
+#[test]
+fn status_width_all_variants() {
+    use crate::core::types::MessageStatus;
+    assert_eq!(display_width_of_status(MessageStatus::Sending), 3);
+    assert_eq!(display_width_of_status(MessageStatus::Sent), 1);
+    assert_eq!(display_width_of_status(MessageStatus::Delivered), 2);
+    assert_eq!(display_width_of_status(MessageStatus::Read), 2);
+    assert_eq!(display_width_of_status(MessageStatus::Failed), 1);
+}
+```
+
+- [ ] **Step 2: Run to confirm compile error (function missing)**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat && cargo test status_width_all_variants -q 2>&1 | head -5
+```
+
+Expected: `error[E0425]: cannot find function \`display_width_of_status\``
+
+- [ ] **Step 3: Add helpers**
+
+Update the module-level import near the top of `message_view.rs`:
+
+```rust
+use crate::core::types::{MessageStatus, UnifiedMessage};
+```
+
+Then add these two functions just before `render_message_view` (before the `#[allow(clippy::too_many_arguments)]` attribute):
+
+```rust
+/// Returns the display column width of the delivery status indicator.
+fn display_width_of_status(status: MessageStatus) -> usize {
+    match status {
+        MessageStatus::Sending => 3,   // "···"  (3 × U+00B7)
+        MessageStatus::Sent => 1,      // "✓"
+        MessageStatus::Delivered => 2, // "✓✓"
+        MessageStatus::Read => 2,      // "✓✓"
+        MessageStatus::Failed => 1,    // "✗"
+    }
+}
+
+/// Returns the styled delivery-status span.
+fn status_span(status: MessageStatus) -> Span<'static> {
+    let (text, color) = match status {
+        MessageStatus::Sending => ("···", Color::DarkGray),
+        MessageStatus::Sent => ("✓", Color::DarkGray),
+        MessageStatus::Delivered => ("✓✓", Color::DarkGray),
+        MessageStatus::Read => ("✓✓", Color::Green),
+        MessageStatus::Failed => ("✗", Color::Red),
+    };
+    Span::styled(text, Style::default().fg(color))
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat && cargo test status_width_all_variants -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat
+git add src/tui/widgets/message_view.rs
+git commit -m "$(cat <<'EOF'
+feat: add display_width_of_status and status_span helpers
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: `build_content_spans` helper + incoming/outgoing bubble rendering
+
+**Files:**
+- Modify: `src/tui/widgets/message_view.rs`
+
+- [ ] **Step 1: Add `build_content_spans` helper**
+
+Add this function after `split_line_with_urls` (after line 126):
+
+```rust
+/// Build content spans for a single pre-wrapped line with optional URL styling.
+/// `is_selected`: adds blue background when true.
+/// `text_color`: base message text color.
+fn build_content_spans(line: &str, is_selected: bool, text_color: Color) -> Vec<Span<'static>> {
+    let bg = if is_selected { Color::Blue } else { Color::Black };
+    let url_style = Style::default()
+        .fg(Color::LightBlue)
+        .add_modifier(Modifier::UNDERLINED)
+        .bg(bg);
+
+    if !line.contains("http://") && !line.contains("https://") {
+        return vec![Span::styled(
+            line.to_string(),
+            Style::default().fg(text_color).bg(bg),
+        )];
+    }
+
+    split_line_with_urls(line)
+        .into_iter()
+        .map(|(seg, is_url)| {
+            if is_url {
+                Span::styled(seg.to_string(), url_style)
+            } else {
+                Span::styled(seg.to_string(), Style::default().fg(text_color).bg(bg))
+            }
+        })
+        .collect()
+}
+```
+
+Note: uses `Color::Black` as the non-selected background (matches terminal default).
+
+- [ ] **Step 2: Replace `render_message_view` message loop**
+
+Replace the entire `for (i, msg) in messages.iter().enumerate() {` loop (lines 178–332) with:
+
+```rust
+    for (i, msg) in messages.iter().enumerate() {
+        // Insert "─── N new ───" separator before first new message
+        if Some(i) == new_start_idx {
+            let content_width = area.width.saturating_sub(2) as usize;
+            let label = format!(" {} new ", new_message_count);
+            let dashes = content_width.saturating_sub(label.len());
+            let left = dashes / 2;
+            let right = dashes - left;
+            let separator = format!("{}{}{}", "─".repeat(left), label, "─".repeat(right));
+            lines.push(Line::styled(separator, Style::default().fg(Color::Yellow)));
+        }
+
+        let time = msg
+            .timestamp
+            .with_timezone(&Local)
+            .format("%H:%M")
+            .to_string();
+        let is_selected = selected_message_idx == Some(i);
+
+        // Group boundary: direction flip, different sender, or >5min gap
+        let prev = if i > 0 { messages.get(i - 1) } else { None };
+        let is_group_start = match prev {
+            None => true,
+            Some(p) => {
+                p.is_outgoing != msg.is_outgoing
+                    || p.sender != msg.sender
+                    || (msg.timestamp - p.timestamp).num_seconds().abs() > 300
+            }
+        };
+
+        // Blank separator between groups (not before the very first message)
+        if is_group_start && i > 0 {
+            lines.push(Line::from(""));
+        }
+
+        let area_w = area.width.saturating_sub(2) as usize;
+        let sender_display = if msg.sender.is_empty() {
+            "(unknown)".to_string()
+        } else {
+            msg.sender.clone()
+        };
+
+        if msg.is_outgoing {
+            // ── Outgoing: right-aligned, cyan ┃ ──────────────────────────────
+            let name = sender_display.clone();
+            if is_group_start {
+                let header = format!("{} {}", name, time);
+                let pad = area_w.saturating_sub(header.len());
+                let header_line = if is_selected {
+                    Line::from(vec![
+                        Span::raw(" ".repeat(pad)),
+                        Span::styled(name.clone(), Style::default().bg(Color::Blue).fg(Color::Cyan)),
+                        Span::styled(format!(" {}", time), Style::default().bg(Color::Blue).fg(Color::DarkGray)),
+                        Span::styled(" ▐", Style::default().fg(Color::Cyan).bg(Color::Blue)),
+                    ])
+                } else {
+                    Line::from(vec![
+                        Span::raw(" ".repeat(pad)),
+                        Span::styled(name.clone(), Style::default().fg(Color::Cyan)),
+                        Span::styled(format!(" {}", time), Style::default().fg(Color::DarkGray)),
+                    ])
+                };
+                lines.push(header_line);
+            }
+
+            let max_self_w = (area_w * 2 / 3).max(20);
+            let content_text = msg.content.as_text().to_string();
+            let mut all_wrapped: Vec<String> = Vec::new();
+            for original_line in content_text.split('\n') {
+                all_wrapped.extend(wrap_to_width(original_line, max_self_w));
+            }
+            let total = all_wrapped.len();
+            for (li, text_line) in all_wrapped.iter().enumerate() {
+                let is_last = li == total - 1;
+                let line_w = UnicodeWidthStr::width(text_line.as_str());
+                let mut spans: Vec<Span> = build_content_spans(text_line, is_selected, Color::White);
+                if is_last {
+                    let status_w = display_width_of_status(msg.status);
+                    let pad = area_w.saturating_sub(line_w + 2 + 1 + status_w);
+                    let mut row: Vec<Span> = vec![Span::raw(" ".repeat(pad))];
+                    row.append(&mut spans);
+                    row.push(Span::styled(" ┃", Style::default().fg(Color::Cyan).bg(if is_selected { Color::Blue } else { Color::Black })));
+                    row.push(Span::raw(" "));
+                    row.push({
+                        let mut s = status_span(msg.status);
+                        if is_selected { s = s.patch_style(Style::default().bg(Color::Blue)); }
+                        s
+                    });
+                    lines.push(Line::from(row));
+                } else {
+                    let pad = area_w.saturating_sub(line_w + 2);
+                    let mut row: Vec<Span> = vec![Span::raw(" ".repeat(pad))];
+                    row.append(&mut spans);
+                    row.push(Span::styled(" ┃", Style::default().fg(Color::Cyan).bg(if is_selected { Color::Blue } else { Color::Black })));
+                    lines.push(Line::from(row));
+                }
+            }
+        } else {
+            // ── Incoming: left-aligned, purple ┃ ─────────────────────────────
+            let is_new = new_start_idx.map(|s| i >= s).unwrap_or(false);
+            let name_color = if is_new { Color::Yellow } else { Color::Magenta };
+            let bar_color = if is_new { Color::Yellow } else { Color::Magenta };
+            let msg_color = if is_new { Color::White } else { Color::Gray };
+
+            if is_group_start {
+                let header_line = if is_selected {
+                    Line::from(vec![
+                        Span::styled("▌ ", Style::default().fg(Color::Cyan).bg(Color::Blue)),
+                        Span::styled(sender_display.clone(), Style::default().fg(name_color).bg(Color::Blue)),
+                        Span::styled(format!(" {}", time), Style::default().fg(Color::DarkGray).bg(Color::Blue)),
+                    ])
+                } else {
+                    Line::from(vec![
+                        Span::styled("┃ ", Style::default().fg(bar_color)),
+                        Span::styled(sender_display.clone(), Style::default().fg(name_color)),
+                        Span::styled(format!(" {}", time), Style::default().fg(Color::DarkGray)),
+                    ])
+                };
+                lines.push(header_line);
+            }
+
+            let content_w = area_w.saturating_sub(2); // "┃ " = 2 cols
+            let content_text = msg.content.as_text().to_string();
+            for original_line in content_text.split('\n') {
+                for text_line in wrap_to_width(original_line, content_w) {
+                    let bar = if is_selected {
+                        Span::styled("▌ ", Style::default().fg(Color::Cyan).bg(Color::Blue))
+                    } else {
+                        Span::styled("┃ ", Style::default().fg(bar_color))
+                    };
+                    let mut content_spans = build_content_spans(&text_line, is_selected, msg_color);
+                    let mut row = vec![bar];
+                    row.append(&mut content_spans);
+                    lines.push(Line::from(row));
+                }
+            }
+        }
+    } // end message loop
+```
+
+- [ ] **Step 3: Remove `Wrap` from Paragraph — lines are pre-wrapped**
+
+Lines are now explicitly pre-wrapped before being pushed into `lines`. The `Paragraph` widget must NOT re-wrap them. Replace the paragraph construction near the end of `render_message_view`:
+
+**Old code:**
+```rust
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false })
+        .scroll((effective_scroll, 0));
+```
+
+**New code:**
+```rust
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .scroll((effective_scroll, 0));
+```
+
+Also remove `Wrap` from the ratatui imports at the top of the file:
+
+```rust
+// Remove Wrap from this import:
+use ratatui::widgets::{Block, Borders, Paragraph};
+```
+
+- [ ] **Step 4: Build**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat && cargo build 2>&1 | head -40
+```
+
+Expected: Clean build. Fix any borrow/type errors before continuing.
+
+- [ ] **Step 5: Run all existing tests**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat && cargo test -q 2>&1 | tail -10
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat
+git add src/tui/widgets/message_view.rs
+git commit -m "$(cat <<'EOF'
+feat: replace gutter with colored bar bubble style (Feature F)
+
+- Incoming: left purple ┃ with name/timestamp header on group start
+- Outgoing: right-padded cyan ┃ with delivery status indicator
+- Groups separated by blank line on sender/direction change or >5min gap
+- Remove Wrap option from Paragraph since lines are pre-wrapped
+- build_content_spans helper for URL-aware line rendering
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Fix scroll estimation
+
+**Files:**
+- Modify: `src/tui/widgets/message_view.rs`
+
+Lines are now pre-wrapped and `Wrap` is removed from the Paragraph widget, so each `Line` in the vec is exactly one terminal row. The scroll estimation can be simplified to `lines.len()`.
+
+- [ ] **Step 1: Write a test confirming pre-wrap line count**
+
+Add to the `#[cfg(test)]` block:
+
+```rust
+#[test]
+fn pre_wrap_one_line_per_terminal_row() {
+    // 50-char string at max_w=40 wraps to 2 lines
+    let text = "a".repeat(50);
+    let wrapped = wrap_to_width(&text, 40);
+    assert_eq!(wrapped.len(), 2);
+    // 50-char string at max_w=60 stays 1 line
+    let wrapped2 = wrap_to_width(&text, 60);
+    assert_eq!(wrapped2.len(), 1);
+}
+```
+
+Run: `cargo test pre_wrap_one_line -q` — Expected: PASS.
+
+- [ ] **Step 2: Replace the scroll estimation block**
+
+Replace lines 341–366 (the `// Auto-scroll: estimate total visual lines...` comment through `let auto_scroll = ...`) with:
+
+```rust
+    // Auto-scroll: each Line in `lines` is a pre-wrapped single terminal row
+    // (Wrap is not set on the Paragraph, so no re-wrapping occurs at render time).
+    let visible_height = area.height.saturating_sub(2) as usize;
+    let total_lines = lines.len();
+    let auto_scroll = if total_lines > visible_height {
+        (total_lines - visible_height) as u16
+    } else {
+        0
+    };
+```
+
+- [ ] **Step 3: Build and run tests**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat && cargo test -q 2>&1 | tail -5
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat
+git add src/tui/widgets/message_view.rs
+git commit -m "$(cat <<'EOF'
+feat: simplify scroll estimation for pre-wrapped bubble lines
+
+Each Line is now exactly one terminal row (Wrap removed),
+so scroll total = lines.len() directly.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Chunk 2: Feature C — Activity Graph Column
+
+### Task 4: Braille encoder and SQL query
+
+**Files:**
+- Create: `src/storage/activity.rs`
+- Modify: `src/storage/mod.rs`
+
+- [ ] **Step 1: Check `src/storage/mod.rs` for existing `pub mod` declarations**
+
+```bash
+cat /home/weibin/repo/ai/zero-drift-chat/src/storage/mod.rs
+```
+
+Note the existing module names; you will add `pub mod activity;` alongside them.
+
+- [ ] **Step 2: Create `src/storage/activity.rs` with tests**
+
+```rust
+// src/storage/activity.rs
+use std::collections::HashMap;
+
+use crate::storage::db::Database;
+
+/// Encode a 24-hour hourly bucket array into a 10-character Braille sparkline.
+/// `array[23]` = current hour, `array[0]` = 23 hours ago.
+/// Renders the most recent 10 hours (indices 14..=23).
+pub fn encode_braille(array: &[u32; 24]) -> String {
+    const BRAILLE: [char; 9] = ['⠀', '⣀', '⣄', '⣆', '⣇', '⣧', '⣷', '⣾', '⣿'];
+    let slice = &array[14..]; // 10 elements: indices 14..=23
+    let max_val = *slice.iter().max().unwrap_or(&0);
+    if max_val == 0 {
+        return BRAILLE[0].to_string().repeat(10);
+    }
+    slice
+        .iter()
+        .map(|&v| BRAILLE[((v * 8) / max_val).min(8) as usize])
+        .collect()
+}
+
+/// Query 24-hour message activity bucketed by hour for a list of chat IDs.
+/// Returns chat_id → [u32; 24] where index 23 = current hour, index 0 = 23 hours ago.
+/// Returns an empty map if `chat_ids` is empty.
+///
+/// Note: slot 23 corresponds to the current clock hour. A new message arriving just
+/// after an hour boundary will be counted in slot 23 until the next full refresh
+/// (~5 min). This ±1 bucket inaccuracy is acceptable per spec.
+pub fn query_activity_24h(db: &Database, chat_ids: &[&str]) -> HashMap<String, [u32; 24]> {
+    if chat_ids.is_empty() {
+        return HashMap::new();
+    }
+
+    let placeholders: String = chat_ids
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format!("?{}", i + 1))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    // strftime('%s', ...) has broader SQLite compatibility than unixepoch()
+    // (works from SQLite 3.8+, whereas unixepoch() requires 3.38+).
+    // Timestamps are stored as RFC 3339 strings.
+    let sql = format!(
+        "SELECT chat_id,
+                CAST((CAST(strftime('%s', 'now') AS INTEGER)
+                      - CAST(strftime('%s', timestamp) AS INTEGER)) / 3600 AS INTEGER) AS hours_ago,
+                COUNT(*) AS cnt
+         FROM messages
+         WHERE CAST(strftime('%s', timestamp) AS INTEGER)
+               > CAST(strftime('%s', 'now') AS INTEGER) - 86400
+           AND chat_id IN ({placeholders})
+         GROUP BY chat_id, hours_ago"
+    );
+
+    let mut result: HashMap<String, [u32; 24]> = HashMap::new();
+
+    let query_result = db.conn.prepare(&sql).and_then(|mut stmt| {
+        let params: Vec<&dyn rusqlite::ToSql> =
+            chat_ids.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+        let rows = stmt.query_map(params.as_slice(), |row| {
+            let chat_id: String = row.get(0)?;
+            let hours_ago: i64 = row.get(1)?;
+            let cnt: u32 = row.get(2)?;
+            Ok((chat_id, hours_ago, cnt))
+        })?;
+        rows.collect::<Result<Vec<_>, _>>()
+    });
+
+    match query_result {
+        Ok(triples) => {
+            for (chat_id, hours_ago, cnt) in triples {
+                if hours_ago < 0 || hours_ago > 23 {
+                    continue;
+                }
+                let slot = 23 - hours_ago as usize;
+                result.entry(chat_id).or_insert([0u32; 24])[slot] = cnt;
+            }
+        }
+        Err(e) => {
+            tracing::warn!("activity query failed: {}", e);
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{encode_braille, query_activity_24h};
+    use crate::storage::db::Database;
+
+    #[test]
+    fn all_zero_returns_blank_braille() {
+        let arr = [0u32; 24];
+        let result = encode_braille(&arr);
+        assert_eq!(result.chars().count(), 10);
+        assert!(result.chars().all(|c| c == '⠀'));
+    }
+
+    #[test]
+    fn single_spike_at_current_hour() {
+        let mut arr = [0u32; 24];
+        arr[23] = 100;
+        let result = encode_braille(&arr);
+        let chars: Vec<char> = result.chars().collect();
+        assert_eq!(chars.len(), 10);
+        assert_eq!(*chars.last().unwrap(), '⣿');
+        for c in &chars[..9] {
+            assert_eq!(*c, '⠀');
+        }
+    }
+
+    #[test]
+    fn uniform_distribution_all_same_level() {
+        let mut arr = [0u32; 24];
+        for i in 14..24 {
+            arr[i] = 50;
+        }
+        let result = encode_braille(&arr);
+        let chars: Vec<char> = result.chars().collect();
+        let first = chars[0];
+        assert!(chars.iter().all(|&c| c == first));
+        assert_ne!(first, '⠀');
+    }
+
+    #[test]
+    fn indices_outside_14_23_are_ignored() {
+        // Spike at index 0 is outside the [14..] slice, should not affect output
+        let mut arr = [0u32; 24];
+        arr[0] = 9999;
+        arr[23] = 1;
+        let chars: Vec<char> = encode_braille(&arr).chars().collect();
+        assert_eq!(*chars.last().unwrap(), '⣿');
+        for c in &chars[..9] {
+            assert_eq!(*c, '⠀');
+        }
+    }
+
+    #[test]
+    fn max_val_zero_no_panic() {
+        let arr = [0u32; 24];
+        let r = encode_braille(&arr);
+        assert_eq!(r.chars().count(), 10);
+    }
+
+    #[test]
+    fn empty_chat_ids_returns_empty_map() {
+        let db = Database::open_in_memory().expect("in-memory db");
+        let result = query_activity_24h(&db, &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn query_with_no_matching_messages_returns_empty() {
+        let db = Database::open_in_memory().expect("in-memory db");
+        let result = query_activity_24h(&db, &["chat_nonexistent"]);
+        assert!(result.is_empty());
+    }
+}
+```
+
+- [ ] **Step 3: Register the module**
+
+Open `src/storage/mod.rs` and add:
+
+```rust
+pub mod activity;
+```
+
+alongside the existing `pub mod` declarations found in Step 1.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat && cargo test storage::activity:: -q
+```
+
+Expected: All 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat
+git add src/storage/activity.rs src/storage/mod.rs
+git commit -m "$(cat <<'EOF'
+feat: add activity Braille encoder and 24h SQL query (Feature C)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: AppState — add activity cache fields
+
+**Files:**
+- Modify: `src/tui/app_state.rs`
+
+- [ ] **Step 1: Add fields to `AppState` struct**
+
+In `src/tui/app_state.rs`, find `pub blink_phase: u8,` (line ~362). Add after it:
+
+```rust
+    /// Per-chat 24h activity cache: chat_id → [u32; 24].
+    /// Index 23 = current hour, index 0 = 23 hours ago.
+    pub activity_cache: std::collections::HashMap<String, [u32; 24]>,
+    /// `tick_count` value when the last full SQL activity refresh ran.
+    pub activity_last_refresh_tick: u64,
+```
+
+- [ ] **Step 2: Initialize in `AppState::new()`**
+
+In `AppState::new()`, add after `blink_phase: 0,`:
+
+```rust
+            activity_cache: std::collections::HashMap::new(),
+            activity_last_refresh_tick: 0,
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat && cargo build -q 2>&1 | head -10
+```
+
+Expected: Clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat
+git add src/tui/app_state.rs
+git commit -m "$(cat <<'EOF'
+feat: add activity_cache fields to AppState
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Wire activity refresh in `app.rs`
+
+**Files:**
+- Modify: `src/app.rs`
+
+- [ ] **Step 1: Add `refresh_activity_cache` method**
+
+Add this method to `impl App` (alongside `handle_tick`):
+
+```rust
+    fn refresh_activity_cache(&mut self) {
+        let chat_ids: Vec<String> = self.state.chats.iter().map(|c| c.id.clone()).collect();
+        let id_refs: Vec<&str> = chat_ids.iter().map(|s| s.as_str()).collect();
+        let cache = crate::storage::activity::query_activity_24h(&self.db, &id_refs);
+        self.state.activity_cache = cache;
+    }
+```
+
+- [ ] **Step 2: Call on startup**
+
+In `run()`, after `self.load_selected_chat_messages();` (~line 203), add:
+
+```rust
+        // Populate activity cache before first render
+        self.refresh_activity_cache();
+        self.state.activity_last_refresh_tick = 0;
+```
+
+- [ ] **Step 3: Periodic refresh in `handle_tick`**
+
+In `handle_tick`, after `self.tick_count += 1;` (~line 354), add:
+
+```rust
+        // Refresh activity cache every 1200 ticks (~5 minutes at 250ms/tick)
+        if self.tick_count.saturating_sub(self.state.activity_last_refresh_tick) >= 1200 {
+            self.state.activity_last_refresh_tick = self.tick_count;
+            self.refresh_activity_cache();
+        }
+```
+
+- [ ] **Step 4: Increment on new message**
+
+In the `ProviderEvent::NewMessage(msg)` handler (~line 367), after `self.db.insert_message(&msg)`, add:
+
+```rust
+                    // Increment activity cache for the current hour bucket (slot 23).
+                    // ±1 bucket error possible within 5 min of an hour boundary;
+                    // the next full refresh corrects it automatically.
+                    self.state.activity_cache
+                        .entry(msg.chat_id.clone())
+                        .or_insert([0u32; 24])[23] += 1;
+```
+
+- [ ] **Step 5: Build**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat && cargo build 2>&1 | head -20
+```
+
+Expected: Clean. If `run()` already has `&mut self`, the startup call compiles without changes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat
+git add src/app.rs
+git commit -m "$(cat <<'EOF'
+feat: wire activity cache refresh on startup, tick, and new message
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Chat list — activity graph column
+
+**Files:**
+- Modify: `src/tui/widgets/chat_list.rs`
+- Modify: `src/tui/render.rs`
+
+- [ ] **Step 1: Add `Paragraph` to imports in `chat_list.rs`**
+
+Update the widgets import line (line 7):
+
+```rust
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+```
+
+- [ ] **Step 2: Add `activity_cache` parameter to `render_chat_list`**
+
+Change the function signature (line 85) to:
+
+```rust
+pub fn render_chat_list(
+    f: &mut Frame,
+    area: Rect,
+    chats: &[UnifiedChat],
+    list_state: &mut ListState,
+    active_panel: ActivePanel,
+    input_mode: InputMode,
+    typing_states: &HashMap<String, TypingInfo>,
+    blink_phase: u8,
+    activity_cache: &HashMap<String, [u32; 24]>,
+) {
+```
+
+- [ ] **Step 3: Add horizontal split at the top of `render_chat_list`**
+
+Add this block immediately after the opening `{` of `render_chat_list`, before `let border_color = ...`:
+
+```rust
+    // Wide-screen: split off a 12-col graph column on the right
+    let (list_area, graph_area_opt) = if area.width >= 100 {
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Length(area.width.saturating_sub(12)),
+                Constraint::Length(12),
+            ])
+            .split(area);
+        (chunks[0], Some(chunks[1]))
+    } else {
+        (area, None)
+    };
+```
+
+- [ ] **Step 4: Replace `area` with `list_area` throughout the function body**
+
+The function body uses `area` in four places after the split. Replace each:
+- `let block = Block::default()...` — no change (block is rendered next)
+- `let inner = block.inner(area)` → `let inner = block.inner(list_area)`
+- `f.render_widget(block, area)` → `f.render_widget(block, list_area)`
+- The `f.render_stateful_widget(list, inner, list_state)` call inside the `pinned_count == 0` branch — replace the `return` after it with a `// fall through to graph column` comment and move graph rendering below the if/else. See Step 5.
+
+- [ ] **Step 5: Restructure the `pinned_count == 0` early return**
+
+The original code returns early when there are no pinned chats (line 152). This prevents graph column rendering. Replace the early return with a local variable pattern:
+
+```rust
+    if pinned_count == 0 {
+        // No pinned chats — plain scrollable list
+        let items: Vec<ListItem> = chats
+            .iter()
+            .enumerate()
+            .map(|(i, chat)| {
+                let blink = typing_states.get(&chat.id).map(|_| blink_phase);
+                make_item(chat, i == selected, blink)
+            })
+            .collect();
+        let list = List::new(items).highlight_style(highlight);
+        f.render_stateful_widget(list, inner, list_state);
+        // Do NOT return — fall through to render graph column below
+    } else {
+        // Split inner area: fixed pinned section on top, scrollable unpinned below
+        let sections = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(pinned_count as u16), Constraint::Min(0)])
+            .split(inner);
+
+        // --- Pinned section ---
+        let pinned_items: Vec<ListItem> = chats
+            .iter()
+            .filter(|c| c.is_pinned)
+            .enumerate()
+            .map(|(i, chat)| {
+                let blink = typing_states.get(&chat.id).map(|_| blink_phase);
+                make_item(chat, selected < pinned_count && i == selected, blink)
+            })
+            .collect();
+        let mut pinned_state = ListState::default();
+        if selected < pinned_count {
+            pinned_state.select(Some(selected));
+        }
+        let pinned_list = List::new(pinned_items).highlight_style(highlight);
+        f.render_stateful_widget(pinned_list, sections[0], &mut pinned_state);
+
+        // --- Unpinned section ---
+        let unpinned_items: Vec<ListItem> = chats
+            .iter()
+            .filter(|c| !c.is_pinned)
+            .enumerate()
+            .map(|(i, chat)| {
+                let blink = typing_states.get(&chat.id).map(|_| blink_phase);
+                make_item(
+                    chat,
+                    selected >= pinned_count && i == selected - pinned_count,
+                    blink,
+                )
+            })
+            .collect();
+        let mut unpinned_state = ListState::default();
+        if selected >= pinned_count {
+            unpinned_state.select(Some(selected - pinned_count));
+        }
+        let unpinned_list = List::new(unpinned_items).highlight_style(highlight);
+        f.render_stateful_widget(unpinned_list, sections[1], &mut unpinned_state);
+    }
+
+    // Render activity graph column if wide enough
+    if let Some(graph_area) = graph_area_opt {
+        use crate::storage::activity::encode_braille;
+
+        let mut graph_lines: Vec<ratatui::text::Line> = vec![
+            ratatui::text::Line::from(vec![
+                Span::styled(" 24h       ", Style::default().fg(Color::DarkGray)),
+            ]),
+        ];
+        for chat in chats.iter() {
+            let arr = activity_cache
+                .get(&chat.id)
+                .copied()
+                .unwrap_or([0u32; 24]);
+            let braille = encode_braille(&arr);
+            let color = if chat.unread_count > 0 {
+                Color::Green
+            } else {
+                Color::DarkGray
+            };
+            graph_lines.push(ratatui::text::Line::from(vec![
+                Span::raw(" "),
+                Span::styled(braille, Style::default().fg(color)),
+                Span::raw(" "),
+            ]));
+        }
+
+        let graph_widget = Paragraph::new(graph_lines);
+        f.render_widget(graph_widget, graph_area);
+    }
+```
+
+- [ ] **Step 6: Update the call site in `render.rs`**
+
+In `src/tui/render.rs`, find the `chat_list::render_chat_list(...)` call (lines 56–65). Add the new argument:
+
+```rust
+    chat_list::render_chat_list(
+        f,
+        chat_list_area,
+        &state.chats,
+        &mut state.chat_list_state,
+        state.active_panel,
+        state.input_mode,
+        &state.typing_states,
+        state.blink_phase,
+        &state.activity_cache,   // ← new
+    );
+```
+
+- [ ] **Step 7: Build**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat && cargo build 2>&1 | head -40
+```
+
+Expected: Clean. Fix any import or borrow errors.
+
+- [ ] **Step 8: Run all tests**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat && cargo test -q 2>&1 | tail -10
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat
+git add src/tui/widgets/chat_list.rs src/tui/render.rs
+git commit -m "$(cat <<'EOF'
+feat: add 24h activity graph column to chat list (Feature C)
+
+Shows Braille sparkline column when terminal width >= 100 cols.
+Column is borderless (12 cols: 1 pad + 10 Braille + 1 pad).
+Graph aligns with both pinned and unpinned chat rows.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Manual verification (Feature C)
+
+- [ ] **Step 1: Verify app starts without crash**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat && cargo run 2>/dev/null
+```
+
+Expected: App launches, no panic on startup.
+
+- [ ] **Step 2: Test activity graph at wide terminal (≥100 cols)**
+
+Resize terminal to ≥100 columns. Verify:
+- A `24h` header row appears on the right of the chat list
+- Each chat row shows a 10-char Braille sparkline next to it
+- Chats with unread messages show green sparklines; others show DarkGray
+
+- [ ] **Step 3: Test narrow terminal (<100 cols)**
+
+Resize terminal to <100 columns. Verify:
+- Activity graph column disappears
+- Chat list fills full width as before
+
+- [ ] **Step 4: Verify Feature F visuals**
+
+While running with any terminal width, confirm:
+- Incoming messages show purple `┃` on the left with name + timestamp header
+- Outgoing messages are right-aligned with cyan `┃` and delivery status
+- Consecutive same-sender messages share a single header
+- A blank separator line appears between groups
+
+- [ ] **Step 5: Check git log**
+
+```bash
+cd /home/weibin/repo/ai/zero-drift-chat && git log --oneline -10
+```
+
+Expected: All feature commits visible in order.

--- a/docs/superpowers/specs/2026-03-17-btop-ui-enhancements-design.md
+++ b/docs/superpowers/specs/2026-03-17-btop-ui-enhancements-design.md
@@ -1,0 +1,274 @@
+# btop-Inspired UI Enhancements Design
+
+**Date:** 2026-03-17
+**Status:** Approved
+**Features:** Message bubble style (F) + Activity graph column (C)
+
+---
+
+## Overview
+
+Two parallel visual enhancements inspired by btop's UI design philosophy:
+
+1. **Colored-bar message bubbles** — replace the current `▌`/`▐` gutter with colored `┃` vertical bars that distinguish sender vs receiver, with right-aligned self-messages and delivery indicators.
+2. **Activity graph column** — show a Braille sparkline of 24-hour message frequency per chat in a side column of the chat list, visible when terminal width ≥ 100 columns.
+
+Both features are always-on (no toggle). Both are implemented in parallel.
+
+---
+
+## Feature F: Colored-Bar Message Bubbles
+
+### Sender Detection
+
+Use `msg.is_outgoing: bool` (present on `UnifiedMessage`) for left/right split. Use `msg.sender: String` for display name.
+
+### Grouping Logic
+
+Track `prev_is_outgoing: Option<bool>` and `prev_sender: Option<String>` while iterating messages. A **group boundary** occurs when either:
+- `msg.is_outgoing != prev_is_outgoing` (direction flip), OR
+- `msg.sender != prev_sender` (different sender in group chat), OR
+- time gap > 5 minutes between consecutive messages
+
+Insert one blank separator line at each group boundary. `prev_is_outgoing` drives the direction choice; `prev_sender` handles same-direction multi-sender groups. Both fields are necessary.
+
+Name/timestamp header is rendered only on the first message of each group.
+
+### Delivery Status Indicator
+
+`UnifiedMessage` has `status: MessageStatus` with variants `Sending`, `Sent`, `Delivered`, `Read`, `Failed`.
+
+| Status | Indicator | Color |
+|--------|-----------|-------|
+| `Sending` | `···` | DarkGray |
+| `Sent` | `✓` | DarkGray |
+| `Delivered` | `✓✓` | DarkGray |
+| `Read` | `✓✓` | Green |
+| `Failed` | `✗` | Red |
+
+The indicator is appended **after** `┃` on the last line of every outgoing message, separated by one space: `Cyan("┃") + " " + colored_status`. The pad calculation for the last content line must reserve space for the status: `pad = area_w - line_w - 2 - 1 - status_w` where `2` = space+`┃`, `1` = separator space, `status_w` = display width of the status string. Non-last lines use `pad = area_w - line_w - 2`.
+
+**Status display widths** (all characters have width 1 per `unicode-width` crate):
+
+| Status | Indicator | `status_w` |
+|--------|-----------|------------|
+| `Sending` | `···` (3× U+00B7) | 3 |
+| `Sent` | `✓` (U+2713) | 1 |
+| `Delivered` | `✓✓` | 2 |
+| `Read` | `✓✓` | 2 |
+| `Failed` | `✗` (U+2717) | 1 |
+
+`display_width_of_status(s: MessageStatus) -> usize` returns these values directly (no runtime Unicode measurement needed).
+
+### Right-Aligned Layout
+
+All arithmetic in `usize` (cast `area.width as usize` per existing pattern in the codebase).
+
+```
+area_w = area.width as usize
+max_self_w = area_w * 2 / 3
+
+// Wrap content
+lines = wrap_to_width(&content, max_self_w)
+
+// Header line (name + timestamp), right-aligned
+header = format!("{name} {timestamp}")
+header_pad = area_w.saturating_sub(header.len())
+render: " ".repeat(header_pad) + Cyan(name) + " " + Gray(timestamp)
+
+// Content lines
+for (i, line) in lines.iter().enumerate() {
+    is_last = i == lines.len() - 1
+    line_w  = UnicodeWidthStr::width(line.as_str())
+    if is_last {
+        status_w = display_width_of_status(msg.status)
+        pad = area_w.saturating_sub(line_w + 2 + 1 + status_w)
+        render: " ".repeat(pad) + line + " " + Cyan("┃") + " " + colored_status
+    } else {
+        pad = area_w.saturating_sub(line_w + 2)
+        render: " ".repeat(pad) + line + " " + Cyan("┃")
+    }
+}
+```
+
+### Scroll Estimation Fix
+
+The existing estimation loop in `message_view.rs` uses a single `bubble_max_w`. Branch on `msg.is_outgoing`:
+
+```rust
+let max_w = if msg.is_outgoing {
+    area.width as usize * 2 / 3
+} else {
+    area.width.saturating_sub(2) as usize
+};
+let wrapped_count = wrap_to_width(&line, max_w).len();
+```
+
+### Message Selection Mode
+
+The existing code uses `▌` on the left for incoming selected messages and `▐` on the right for outgoing selected messages.
+
+- **Incoming messages:** `▌` is a left-side gutter; the new `┃` is also left-side. In `MessageSelect` mode, render `▌` + blue background in place of `┃` for the selected message row. No structural change needed.
+- **Outgoing messages:** `▐` is a right-side marker; the new `┃` is also right-side. In `MessageSelect` mode, render `▐` + blue background in place of `┃` for the selected message row.
+
+Both selection markers are retained exactly as implemented today; only the non-selected gutter character changes (`▌`/`▐` → `┃`).
+
+### File
+
+`src/tui/widgets/message_view.rs` — replace gutter + `sender: content` rendering logic.
+
+---
+
+## Feature C: Activity Graph Column
+
+### New File: `src/storage/activity.rs`
+
+```rust
+/// Returns message counts bucketed by hour for the past 24h.
+/// Index 0 = 23 hours ago, index 23 = the current (most recent) hour.
+pub fn query_activity_24h(
+    db: &Database,
+    chat_ids: &[&str],
+) -> HashMap<String, [u32; 24]>
+```
+
+Note: use `Database` (the actual type from `src/storage/db.rs`).
+
+**Handling variable-length IN clause:** rusqlite does not support binding a slice to `IN (?)`. Build the placeholder list dynamically:
+
+```rust
+let placeholders = chat_ids.iter().enumerate()
+    .map(|(i, _)| format!("?{}", i + 1))
+    .collect::<Vec<_>>()
+    .join(", ");
+let sql = format!(
+    "SELECT chat_id, \
+     CAST((unixepoch('now') - unixepoch(timestamp)) / 3600 AS INTEGER) AS hours_ago, \
+     COUNT(*) AS cnt \
+     FROM messages \
+     WHERE unixepoch(timestamp) > unixepoch('now') - 86400 \
+       AND chat_id IN ({placeholders}) \
+     GROUP BY chat_id, hours_ago"
+);
+// bind chat_ids[0], chat_ids[1], ... positionally
+```
+
+Map result into `[u32; 24]`: `array[23 - hours_ago] = cnt`. Rows with `hours_ago > 23` are discarded.
+
+**SQLite version requirement:** `unixepoch()` accepting RFC 3339 strings requires SQLite ≥ 3.38.0 (2022-02-22). If the bundled `rusqlite` uses an older SQLite (check via `rusqlite::version()`), use `strftime('%s', timestamp)` as a drop-in replacement with identical semantics and wider compatibility:
+```sql
+WHERE CAST(strftime('%s', timestamp) AS INTEGER) > strftime('%s', 'now') - 86400
+CAST((strftime('%s', 'now') - CAST(strftime('%s', timestamp) AS INTEGER)) / 3600 AS INTEGER) AS hours_ago
+```
+
+### Braille Encoding
+
+Map `[u32; 24]` → 10-character Braille string using the most recent 10 hours.
+
+**Braille character display width:** All Braille Pattern characters (U+2800–U+28FF) have display width **1** per the `unicode-width` crate (which zero-drift-chat already uses via `UnicodeWidthStr`). The 12-column `right_area` budget is calculated on this basis: 1 left-pad + 10 Braille chars × 1 col each + 1 right-pad = 12 cols. If a target terminal renders these as width 2, the column will overflow — this is an inherent terminal font dependency and out of scope for this spec.
+
+```rust
+// In Rust: array[14..] gives indices 14..=23 (10 elements), inclusive on both ends.
+// (Rust ranges are exclusive-end: [14..24] == [14..] on a length-24 array)
+let slice = &array[14..];   // 10 elements: indices 14, 15, ..., 23
+
+let max_val = *slice.iter().max().unwrap_or(&0);
+if max_val == 0 {
+    return "⠀".repeat(10);   // guard FIRST, before any division
+}
+const BRAILLE: [char; 9] = ['⠀','⣀','⣄','⣆','⣇','⣧','⣷','⣾','⣿'];
+slice.iter()
+    .map(|&v| BRAILLE[((v * 8) / max_val).min(8) as usize])
+    .collect()
+```
+
+Color: `Green` when `chat.unread_count > 0`, `DarkGray` otherwise.
+
+### AppState Changes
+
+```rust
+// In AppState
+activity_cache: HashMap<String, [u32; 24]>,  // chat_id → hourly buckets; index 23 = current hour
+activity_last_refresh_tick: u64,              // value of tick_count at last full SQL refresh
+```
+
+**Initial values in `AppState::new()`:**
+```rust
+activity_cache: HashMap::new(),
+activity_last_refresh_tick: 0,
+```
+
+**Refresh schedule** (tick rate ≈ 250 ms → 1200 ticks ≈ 5 min):
+
+| Trigger | Action |
+|---------|--------|
+| Startup (after chats load) | Full SQL query for all chat IDs |
+| `tick_count - activity_last_refresh_tick >= 1200` | Full SQL query for all chat IDs |
+| New message received for `chat_id` | `activity_cache.entry(chat_id).or_insert([0u32; 24])[23] += 1` |
+
+**Missing chat IDs:** Use `entry().or_insert([0u32; 24])` on increment so new chats arriving mid-session are initialized to zero before the first full refresh.
+
+**Hour boundary rotation:** ±1 bucket inaccuracy within 5 minutes of an hour boundary is acceptable. The full refresh re-derives all arrays from SQL and corrects any drift. No manual rotation is needed.
+
+### `chat_list.rs` Layout
+
+The graph column is a horizontal split applied to `area` **before** the existing vertical (pinned/unpinned) split:
+
+```
+area (full chat panel)
+  └─ horizontal split: [area.width.saturating_sub(12), 12]
+        ├─ left_area  → existing logic: vertical split into pinned + unpinned sections
+        └─ right_area → graph column (borderless; 12 cols = 10 Braille chars + 2 padding cols)
+```
+
+**Data plumbing:** The horizontal split and graph column rendering happen inside `render_chat_list` (in `chat_list.rs`). Add `activity_cache: &HashMap<String, [u32; 24]>` as a new parameter to `render_chat_list`. The call site in `render.rs` passes `&app_state.activity_cache`. When `area.width < 100`, the parameter is accepted but unused.
+
+The `right_area` is rendered **without a Block border** so the 10-character Braille string fits exactly within 10 columns with 1 column left-pad and 1 column right-pad.
+
+The graph column renders a `24h` header in the first row (DarkGray, centered), then one Braille string per visible chat row in the same row order as `left_area`.
+
+When `area.width < 100`: skip the horizontal split entirely; `left_area = area`; graph column not rendered.
+
+---
+
+## Error Handling
+
+- **Activity query fails**: log warning, leave `activity_cache` stale; blank graph (`⠀`×10) for any chat not in cache.
+- **`sender` empty string**: display as `(unknown)`.
+- **`status` unavailable**: treat as `Sent` (single gray `✓`).
+
+---
+
+## Testing
+
+**`activity.rs`:**
+- Braille encoding: all-zero input → `⠀`×10
+- Braille encoding: single spike at index 23 → rightmost char is `⣿`, rest `⠀`
+- Braille encoding: uniform distribution → all chars same non-blank level
+- SQL: dynamic placeholder building for 0, 1, and N chat IDs
+- `entry().or_insert` initializes missing keys correctly
+
+**`message_view.rs`:**
+- Grouping: consecutive same-sender → header only on first; alternating senders → separator each time
+- Direction flip (`is_outgoing` changes) → separator inserted
+- Right-pad: `saturating_sub` prevents underflow on very long lines
+- Last-line pad accounts for status indicator width
+- Scroll estimation: `is_outgoing` branches use correct max widths
+
+**Manual:**
+- Verify layout at 80, 100, 120, 160 column widths
+- Verify graph column aligns with chat rows in both pinned and unpinned sections
+- Verify `▌`/`▐` selection markers still appear in `MessageSelect` mode
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/tui/widgets/message_view.rs` | Replace gutter with colored ┃; two max-widths for scroll estimation |
+| `src/tui/widgets/chat_list.rs` | Horizontal split for graph column, compose with existing vertical split |
+| `src/tui/app_state.rs` | Add `activity_cache`, `activity_last_refresh_tick` |
+| `src/storage/activity.rs` | **New** — 24h SQL query + Braille encoder |
+| `src/storage/db.rs` | Expose `Database` ref to activity query |
+| `src/app.rs` | Wire activity refresh on startup and every 1200 ticks |

--- a/src/app.rs
+++ b/src/app.rs
@@ -202,6 +202,10 @@ impl App {
         // Load messages for the initially selected chat
         self.load_selected_chat_messages();
 
+        // Populate activity cache before first render
+        self.refresh_activity_cache();
+        self.state.activity_last_refresh_tick = 0;
+
         // Send any overdue scheduled messages
         self.check_scheduled_messages().await;
 
@@ -336,6 +340,13 @@ impl App {
         Ok(())
     }
 
+    fn refresh_activity_cache(&mut self) {
+        let chat_ids: Vec<String> = self.state.chats.iter().map(|c| c.id.clone()).collect();
+        let id_refs: Vec<&str> = chat_ids.iter().map(|s| s.as_str()).collect();
+        let cache = crate::storage::activity::query_activity_24h(&self.db, &id_refs);
+        self.state.activity_cache = cache;
+    }
+
     fn handle_tick(&mut self) {
         // Clear transient copy status after one tick so it disappears quickly
         self.state.copy_status = None;
@@ -352,6 +363,13 @@ impl App {
 
         // Advance tick counter and drive typing indicator animation
         self.tick_count += 1;
+
+        // Refresh activity cache every 1200 ticks (~5 minutes at 250ms/tick)
+        if self.tick_count.saturating_sub(self.state.activity_last_refresh_tick) >= 1200 {
+            self.state.activity_last_refresh_tick = self.tick_count;
+            self.refresh_activity_cache();
+        }
+
         let now = std::time::Instant::now();
         self.state.typing_states.retain(|_, v| v.expires_at > now);
         if self.tick_count % 2 == 0 {
@@ -369,6 +387,11 @@ impl App {
                     if let Err(e) = self.db.insert_message(&msg) {
                         tracing::error!("Failed to insert message: {}", e);
                     }
+
+                    // Increment activity cache for the current hour bucket (slot 23).
+                    self.state.activity_cache
+                        .entry(msg.chat_id.clone())
+                        .or_insert([0u32; 24])[23] += 1;
 
                     // Store push_name as contact so we can name phone-number chats
                     if !msg.is_outgoing && msg.sender != "You" && !msg.sender.is_empty() {

--- a/src/storage/activity.rs
+++ b/src/storage/activity.rs
@@ -1,0 +1,226 @@
+// src/storage/activity.rs
+use std::collections::HashMap;
+
+use crate::storage::db::Database;
+
+/// Encode a 24-hour hourly bucket array into a 10-character Braille sparkline.
+/// `array[23]` = current hour, `array[0]` = 23 hours ago.
+/// Renders the most recent 10 hours (indices 14..=23).
+pub fn encode_braille(array: &[u32; 24]) -> String {
+    const BRAILLE: [char; 9] = ['⠀', '⣀', '⣄', '⣆', '⣇', '⣧', '⣷', '⣾', '⣿'];
+    let slice = &array[14..]; // 10 elements: indices 14..=23
+    let max_val = *slice.iter().max().unwrap_or(&0);
+    if max_val == 0 {
+        return BRAILLE[0].to_string().repeat(10);
+    }
+    slice
+        .iter()
+        .map(|&v| BRAILLE[((v * 8) / max_val).min(8) as usize])
+        .collect()
+}
+
+/// Query 24-hour message activity bucketed by hour for a list of chat IDs.
+/// Returns chat_id → [u32; 24] where index 23 = current hour, index 0 = 23 hours ago.
+/// Returns an empty map if `chat_ids` is empty.
+pub fn query_activity_24h(db: &Database, chat_ids: &[&str]) -> HashMap<String, [u32; 24]> {
+    if chat_ids.is_empty() {
+        return HashMap::new();
+    }
+
+    let placeholders: String = chat_ids
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format!("?{}", i + 1))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    // strftime('%s', ...) has broader SQLite compatibility than unixepoch()
+    // (works from SQLite 3.8+, whereas unixepoch() requires 3.38+).
+    // Timestamps are stored as RFC 3339 strings.
+    let sql = format!(
+        "SELECT chat_id,
+                CAST((CAST(strftime('%s', 'now') AS INTEGER)
+                      - CAST(strftime('%s', timestamp) AS INTEGER)) / 3600 AS INTEGER) AS hours_ago,
+                COUNT(*) AS cnt
+         FROM messages
+         WHERE CAST(strftime('%s', timestamp) AS INTEGER)
+               > CAST(strftime('%s', 'now') AS INTEGER) - 86400
+           AND chat_id IN ({placeholders})
+         GROUP BY chat_id, hours_ago"
+    );
+
+    let mut result: HashMap<String, [u32; 24]> = HashMap::new();
+
+    let query_result = db.conn.prepare(&sql).and_then(|mut stmt| {
+        let params: Vec<&dyn rusqlite::ToSql> =
+            chat_ids.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+        // Note: collect aborts on the first row-level error (e.g., NULL hours_ago from
+        // malformed timestamps). A single bad row silently discards the entire result.
+        // The Err arm logs and returns an empty/partial map per spec.
+        let rows = stmt.query_map(params.as_slice(), |row| {
+            let chat_id: String = row.get(0)?;
+            let hours_ago: i64 = row.get(1)?;
+            let cnt: u32 = row.get(2)?;
+            Ok((chat_id, hours_ago, cnt))
+        })?;
+        rows.collect::<Result<Vec<_>, _>>()
+    });
+
+    match query_result {
+        Ok(triples) => {
+            for (chat_id, hours_ago, cnt) in triples {
+                if hours_ago < 0 || hours_ago > 23 {
+                    continue;
+                }
+                let slot = 23 - hours_ago as usize;
+                result.entry(chat_id).or_insert([0u32; 24])[slot] = cnt;
+            }
+        }
+        Err(e) => {
+            tracing::warn!("activity query failed: {}", e);
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{encode_braille, query_activity_24h};
+    use crate::storage::db::Database;
+
+    #[test]
+    fn all_zero_returns_blank_braille() {
+        let arr = [0u32; 24];
+        let result = encode_braille(&arr);
+        assert_eq!(result.chars().count(), 10);
+        assert!(result.chars().all(|c| c == '⠀'));
+    }
+
+    #[test]
+    fn single_spike_at_current_hour() {
+        let mut arr = [0u32; 24];
+        arr[23] = 100;
+        let result = encode_braille(&arr);
+        let chars: Vec<char> = result.chars().collect();
+        assert_eq!(chars.len(), 10);
+        assert_eq!(*chars.last().unwrap(), '⣿');
+        for c in &chars[..9] {
+            assert_eq!(*c, '⠀');
+        }
+    }
+
+    #[test]
+    fn uniform_distribution_all_same_level() {
+        let mut arr = [0u32; 24];
+        for i in 14..24 {
+            arr[i] = 50;
+        }
+        let result = encode_braille(&arr);
+        let chars: Vec<char> = result.chars().collect();
+        let first = chars[0];
+        assert!(chars.iter().all(|&c| c == first));
+        assert_ne!(first, '⠀');
+    }
+
+    #[test]
+    fn indices_outside_14_23_are_ignored() {
+        let mut arr = [0u32; 24];
+        arr[0] = 9999;
+        arr[23] = 1;
+        let chars: Vec<char> = encode_braille(&arr).chars().collect();
+        assert_eq!(*chars.last().unwrap(), '⣿');
+        for c in &chars[..9] {
+            assert_eq!(*c, '⠀');
+        }
+    }
+
+    #[test]
+    fn empty_chat_ids_returns_empty_map() {
+        let db = Database::open_in_memory().expect("in-memory db");
+        let result = query_activity_24h(&db, &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn query_with_no_matching_messages_returns_empty() {
+        let db = Database::open_in_memory().expect("in-memory db");
+        let result = query_activity_24h(&db, &["chat_nonexistent"]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn query_returns_correct_slot_mapping() {
+        let db = Database::open_in_memory().expect("in-memory db");
+
+        // Insert a chat row first (messages has a FK to chats)
+        db.conn.execute(
+            "INSERT INTO chats (id, platform, name) VALUES ('chat_a', 'test', 'Chat A')",
+            [],
+        ).expect("insert chat_a");
+
+        // Insert 3 messages in the current hour (hours_ago = 0, should go to slot 23)
+        for i in 0..3 {
+            db.conn.execute(
+                "INSERT INTO messages (id, chat_id, platform, sender, content, timestamp, status)
+                 VALUES (?1, 'chat_a', 'test', 'user', 'hi',
+                         strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-' || ?2 || ' minutes'),
+                         'delivered')",
+                rusqlite::params![format!("msg_{}", i), i * 5],
+            ).expect("insert message");
+        }
+
+        let result = query_activity_24h(&db, &["chat_a"]);
+
+        assert!(result.contains_key("chat_a"), "chat_a should be in result");
+        let arr = result["chat_a"];
+
+        // Slot 23 = current hour (hours_ago = 0)
+        assert_eq!(arr[23], 3, "slot 23 should have 3 messages");
+
+        // All other slots should be 0
+        for i in 0..23 {
+            assert_eq!(arr[i], 0, "slot {} should be 0", i);
+        }
+    }
+
+    #[test]
+    fn query_multiple_chat_ids() {
+        let db = Database::open_in_memory().expect("in-memory db");
+
+        // Insert chat rows first
+        db.conn.execute(
+            "INSERT INTO chats (id, platform, name) VALUES ('chat_a', 'test', 'Chat A')",
+            [],
+        ).expect("insert chat_a");
+        db.conn.execute(
+            "INSERT INTO chats (id, platform, name) VALUES ('chat_b', 'test', 'Chat B')",
+            [],
+        ).expect("insert chat_b");
+
+        // Insert 2 messages for chat_a and 1 for chat_b
+        db.conn.execute(
+            "INSERT INTO messages (id, chat_id, platform, sender, content, timestamp, status)
+             VALUES ('a1', 'chat_a', 'test', 'user', 'hi',
+                     strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 'delivered')",
+            [],
+        ).expect("insert a1");
+        db.conn.execute(
+            "INSERT INTO messages (id, chat_id, platform, sender, content, timestamp, status)
+             VALUES ('a2', 'chat_a', 'test', 'user', 'hi',
+                     strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-1 minutes'), 'delivered')",
+            [],
+        ).expect("insert a2");
+        db.conn.execute(
+            "INSERT INTO messages (id, chat_id, platform, sender, content, timestamp, status)
+             VALUES ('b1', 'chat_b', 'test', 'user', 'hi',
+                     strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 'delivered')",
+            [],
+        ).expect("insert b1");
+
+        let result = query_activity_24h(&db, &["chat_a", "chat_b"]);
+
+        assert_eq!(result.get("chat_a").map(|a| a[23]), Some(2), "chat_a should have 2 in slot 23");
+        assert_eq!(result.get("chat_b").map(|a| a[23]), Some(1), "chat_b should have 1 in slot 23");
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,3 +1,4 @@
+pub mod activity;
 mod addressbook;
 mod chats;
 pub mod db;

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -360,6 +360,11 @@ pub struct AppState {
     pub typing_states: HashMap<String, TypingInfo>,
     /// Running-light phase: 0=first dot lit, 1=middle, 2=last. Cycles every 2 ticks (~500ms/step).
     pub blink_phase: u8,
+    /// Per-chat 24h activity cache: chat_id → [u32; 24].
+    /// Index 23 = current hour, index 0 = 23 hours ago.
+    pub activity_cache: std::collections::HashMap<String, [u32; 24]>,
+    /// `tick_count` value when the last full SQL activity refresh ran.
+    pub activity_last_refresh_tick: u64,
 }
 
 impl AppState {
@@ -396,6 +401,8 @@ impl AppState {
             schedule_status: None,
             typing_states: HashMap::new(),
             blink_phase: 0,
+            activity_cache: std::collections::HashMap::new(),
+            activity_last_refresh_tick: 0,
         }
     }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -62,6 +62,7 @@ pub fn draw(f: &mut Frame, state: &mut AppState) {
         state.input_mode,
         &state.typing_states,
         state.blink_phase,
+        &state.activity_cache,
     );
 
     message_view::render_message_view(

--- a/src/tui/widgets/chat_list.rs
+++ b/src/tui/widgets/chat_list.rs
@@ -4,7 +4,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, ListState},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
     Frame,
 };
 
@@ -91,7 +91,22 @@ pub fn render_chat_list(
     input_mode: InputMode,
     typing_states: &HashMap<String, TypingInfo>,
     blink_phase: u8,
+    activity_cache: &HashMap<String, [u32; 24]>,
 ) {
+    // Wide-screen: split off a 12-col graph column on the right
+    let (list_area, graph_area_opt) = if area.width >= 100 {
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Length(area.width.saturating_sub(12)),
+                Constraint::Length(12),
+            ])
+            .split(area);
+        (chunks[0], Some(chunks[1]))
+    } else {
+        (area, None)
+    };
+
     let border_color = if active_panel == ActivePanel::ChatList {
         Color::Cyan
     } else {
@@ -124,8 +139,8 @@ pub fn render_chat_list(
         .title_alignment(title_alignment)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
-    let inner = block.inner(area);
-    f.render_widget(block, area);
+    let inner = block.inner(list_area);
+    f.render_widget(block, list_area);
 
     let selected = list_state.selected().unwrap_or(0);
     let pinned_count = chats.iter().filter(|c| c.is_pinned).count();
@@ -149,50 +164,81 @@ pub fn render_chat_list(
         // No highlight_symbol — selector is embedded in item content
         let list = List::new(items).highlight_style(highlight);
         f.render_stateful_widget(list, inner, list_state);
-        return;
+        // Do NOT return — fall through to render graph column below
+    } else {
+        // Split inner area: fixed pinned section on top, scrollable unpinned below
+        let sections = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(pinned_count as u16), Constraint::Min(0)])
+            .split(inner);
+
+        // --- Pinned section (always visible, no scroll) ---
+        let pinned_items: Vec<ListItem> = chats
+            .iter()
+            .filter(|c| c.is_pinned)
+            .enumerate()
+            .map(|(i, chat)| {
+                let blink = typing_states.get(&chat.id).map(|_| blink_phase);
+                make_item(chat, selected < pinned_count && i == selected, blink)
+            })
+            .collect();
+        let mut pinned_state = ListState::default();
+        if selected < pinned_count {
+            pinned_state.select(Some(selected));
+        }
+        let pinned_list = List::new(pinned_items).highlight_style(highlight);
+        f.render_stateful_widget(pinned_list, sections[0], &mut pinned_state);
+
+        // --- Unpinned section (scrollable) ---
+        let unpinned_items: Vec<ListItem> = chats
+            .iter()
+            .filter(|c| !c.is_pinned)
+            .enumerate()
+            .map(|(i, chat)| {
+                let blink = typing_states.get(&chat.id).map(|_| blink_phase);
+                make_item(
+                    chat,
+                    selected >= pinned_count && i == selected - pinned_count,
+                    blink,
+                )
+            })
+            .collect();
+        let mut unpinned_state = ListState::default();
+        if selected >= pinned_count {
+            unpinned_state.select(Some(selected - pinned_count));
+        }
+        let unpinned_list = List::new(unpinned_items).highlight_style(highlight);
+        f.render_stateful_widget(unpinned_list, sections[1], &mut unpinned_state);
     }
 
-    // Split inner area: fixed pinned section on top, scrollable unpinned below
-    let sections = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Length(pinned_count as u16), Constraint::Min(0)])
-        .split(inner);
+    // Render activity graph column if wide enough
+    if let Some(graph_area) = graph_area_opt {
+        use crate::storage::activity::encode_braille;
 
-    // --- Pinned section (always visible, no scroll) ---
-    let pinned_items: Vec<ListItem> = chats
-        .iter()
-        .filter(|c| c.is_pinned)
-        .enumerate()
-        .map(|(i, chat)| {
-            let blink = typing_states.get(&chat.id).map(|_| blink_phase);
-            make_item(chat, selected < pinned_count && i == selected, blink)
-        })
-        .collect();
-    let mut pinned_state = ListState::default();
-    if selected < pinned_count {
-        pinned_state.select(Some(selected));
-    }
-    let pinned_list = List::new(pinned_items).highlight_style(highlight);
-    f.render_stateful_widget(pinned_list, sections[0], &mut pinned_state);
+        let mut graph_lines: Vec<Line> = vec![
+            Line::from(vec![
+                Span::styled(" 24h       ", Style::default().fg(Color::DarkGray)),
+            ]),
+        ];
+        for chat in chats.iter() {
+            let arr = activity_cache
+                .get(&chat.id)
+                .copied()
+                .unwrap_or([0u32; 24]);
+            let braille = encode_braille(&arr);
+            let color = if chat.unread_count > 0 {
+                Color::Green
+            } else {
+                Color::DarkGray
+            };
+            graph_lines.push(Line::from(vec![
+                Span::raw(" "),
+                Span::styled(braille, Style::default().fg(color)),
+                Span::raw(" "),
+            ]));
+        }
 
-    // --- Unpinned section (scrollable) ---
-    let unpinned_items: Vec<ListItem> = chats
-        .iter()
-        .filter(|c| !c.is_pinned)
-        .enumerate()
-        .map(|(i, chat)| {
-            let blink = typing_states.get(&chat.id).map(|_| blink_phase);
-            make_item(
-                chat,
-                selected >= pinned_count && i == selected - pinned_count,
-                blink,
-            )
-        })
-        .collect();
-    let mut unpinned_state = ListState::default();
-    if selected >= pinned_count {
-        unpinned_state.select(Some(selected - pinned_count));
+        let graph_widget = Paragraph::new(graph_lines);
+        f.render_widget(graph_widget, graph_area);
     }
-    let unpinned_list = List::new(unpinned_items).highlight_style(highlight);
-    f.render_stateful_widget(unpinned_list, sections[1], &mut unpinned_state);
 }

--- a/src/tui/widgets/message_view.rs
+++ b/src/tui/widgets/message_view.rs
@@ -1,15 +1,15 @@
 use chrono::Local;
 use ratatui::{
-    layout::{Alignment, Rect},
+    layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, Wrap},
+    widgets::{Block, Borders, Paragraph},
     Frame,
 };
 
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::core::types::UnifiedMessage;
+use crate::core::types::{MessageStatus, UnifiedMessage};
 use crate::tui::app_state::ActivePanel;
 
 /// Word-wrap `text` so each output line is at most `max_w` columns wide.
@@ -125,6 +125,59 @@ fn split_line_with_urls(line: &str) -> Vec<(&str, bool)> {
     result
 }
 
+
+/// Build content spans for a single pre-wrapped line with optional URL styling.
+/// `is_selected`: adds blue background when true.
+/// `text_color`: base message text color.
+fn build_content_spans(line: &str, is_selected: bool, text_color: Color) -> Vec<Span<'static>> {
+    let bg = if is_selected { Color::Blue } else { Color::Black };
+    let url_style = Style::default()
+        .fg(Color::LightBlue)
+        .add_modifier(Modifier::UNDERLINED)
+        .bg(bg);
+
+    if !line.contains("http://") && !line.contains("https://") {
+        return vec![Span::styled(
+            line.to_string(),
+            Style::default().fg(text_color).bg(bg),
+        )];
+    }
+
+    split_line_with_urls(line)
+        .into_iter()
+        .map(|(seg, is_url)| {
+            if is_url {
+                Span::styled(seg.to_string(), url_style)
+            } else {
+                Span::styled(seg.to_string(), Style::default().fg(text_color).bg(bg))
+            }
+        })
+        .collect()
+}
+
+/// Returns the display column width of the delivery status indicator.
+fn display_width_of_status(status: MessageStatus) -> usize {
+    match status {
+        MessageStatus::Sending => 3,   // "···"  (3 × U+00B7)
+        MessageStatus::Sent => 1,      // "✓"
+        MessageStatus::Delivered => 2, // "✓✓"
+        MessageStatus::Read => 2,      // "✓✓"
+        MessageStatus::Failed => 1,    // "✗"
+    }
+}
+
+/// Returns the styled delivery-status span.
+fn status_span(status: MessageStatus) -> Span<'static> {
+    let (text, color) = match status {
+        MessageStatus::Sending => ("···", Color::DarkGray),
+        MessageStatus::Sent => ("✓", Color::DarkGray),
+        MessageStatus::Delivered => ("✓✓", Color::DarkGray),
+        MessageStatus::Read => ("✓✓", Color::Green),
+        MessageStatus::Failed => ("✗", Color::Red),
+    };
+    Span::styled(text, Style::default().fg(color))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn render_message_view(
     f: &mut Frame,
@@ -176,7 +229,7 @@ pub fn render_message_view(
     let mut lines: Vec<Line> = Vec::new();
 
     for (i, msg) in messages.iter().enumerate() {
-        // Insert a full-width "─── N new ───" separator before the first new message
+        // Insert "─── N new ───" separator before first new message
         if Some(i) == new_start_idx {
             let content_width = area.width.saturating_sub(2) as usize;
             let label = format!(" {} new ", new_message_count);
@@ -192,145 +245,126 @@ pub fn render_message_view(
             .with_timezone(&Local)
             .format("%H:%M")
             .to_string();
-        let is_new = new_start_idx.map(|s| i >= s).unwrap_or(false) && !msg.is_outgoing;
         let is_selected = selected_message_idx == Some(i);
 
-        let (sender_color, msg_color) = if msg.is_outgoing {
-            (Color::Green, Color::White)
-        } else if is_new {
-            (Color::Yellow, Color::White)
-        } else {
-            (Color::Cyan, Color::Gray)
-        };
-
-        // Selection highlight style applied to every span in the selected message
-        let select_bg = if is_selected {
-            Style::default().bg(Color::Blue)
-        } else {
-            Style::default()
-        };
-
-        // Left gutter marker: only shown when this message is selected
-        let gutter = "▌ ";
-        let gutter_style = Style::default().fg(Color::Cyan).bg(Color::Blue);
-
-        let header = if msg.is_outgoing {
-            // Right-aligned: "10:02  You" pushed to the right edge
-            let mut line = Line::from(vec![
-                Span::styled(time.clone(), select_bg.fg(Color::DarkGray)),
-                Span::styled(format!("  {}", msg.sender), select_bg.fg(sender_color)),
-            ])
-            .alignment(Alignment::Right);
-            if is_selected {
-                // For outgoing selected, append a trailing marker on the right
-                line = Line::from(vec![
-                    Span::styled(time, select_bg.fg(Color::DarkGray)),
-                    Span::styled(format!("  {}", msg.sender), select_bg.fg(sender_color)),
-                    Span::styled(" ▐", Style::default().fg(Color::Cyan).bg(Color::Blue)),
-                ])
-                .alignment(Alignment::Right);
+        // Group boundary: direction flip, different sender, or >5min gap
+        let prev = if i > 0 { messages.get(i - 1) } else { None };
+        let is_group_start = match prev {
+            None => true,
+            Some(p) => {
+                p.is_outgoing != msg.is_outgoing
+                    || p.sender != msg.sender
+                    || (msg.timestamp - p.timestamp).num_seconds().abs() > 300
             }
-            line
-        } else if is_selected {
-            // Left-aligned selected: cyan gutter + highlighted sender + time
-            Line::from(vec![
-                Span::styled(gutter, gutter_style),
-                Span::styled(format!("{} ", msg.sender), select_bg.fg(sender_color)),
-                Span::styled(time, select_bg.fg(Color::DarkGray)),
-            ])
-        } else {
-            // Left-aligned normal: no gutter
-            Line::from(vec![
-                Span::styled(
-                    format!("{} ", msg.sender),
-                    Style::default().fg(sender_color),
-                ),
-                Span::styled(time, Style::default().fg(Color::DarkGray)),
-            ])
         };
 
-        lines.push(header);
-        let url_style = Style::default()
-            .fg(Color::LightBlue)
-            .add_modifier(Modifier::UNDERLINED);
+        // Blank separator between groups (not before the very first message)
+        if is_group_start && i > 0 {
+            lines.push(Line::from(""));
+        }
 
-        let content_width = area.width.saturating_sub(2) as usize;
-        let bubble_max_w = (content_width * 70 / 100).max(20);
+        let area_w = area.width.saturating_sub(2) as usize;
+        let sender_display = if msg.sender.is_empty() {
+            "(unknown)".to_string()
+        } else {
+            msg.sender.clone()
+        };
 
-        for original_line in msg.content.as_text().split('\n') {
-            for text_line in wrap_to_width(original_line, bubble_max_w) {
-                let text_line = &text_line;
-                let line = if !text_line.contains("http://") && !text_line.contains("https://") {
-                    if is_selected && !msg.is_outgoing {
-                        Line::from(vec![
-                            Span::styled(gutter, gutter_style),
-                            Span::styled(text_line.to_string(), select_bg.fg(msg_color)),
-                        ])
-                    } else if is_selected {
-                        Line::from(Span::styled(text_line.to_string(), select_bg.fg(msg_color)))
-                    } else {
-                        Line::from(Span::styled(
-                            text_line.to_string(),
-                            Style::default().fg(msg_color),
-                        ))
-                    }
+        if msg.is_outgoing {
+            // ── Outgoing: right-aligned, cyan ┃ ──────────────────────────────
+            if is_group_start {
+                let header = format!("{} {}", sender_display, time);
+                let pad = area_w.saturating_sub(header.len());
+                let header_line = if is_selected {
+                    Line::from(vec![
+                        Span::raw(" ".repeat(pad)),
+                        Span::styled(sender_display.clone(), Style::default().bg(Color::Blue).fg(Color::Cyan)),
+                        Span::styled(format!(" {}", time), Style::default().bg(Color::Blue).fg(Color::DarkGray)),
+                        Span::styled(" ▐", Style::default().fg(Color::Cyan).bg(Color::Blue)),
+                    ])
                 } else {
-                    let spans: Vec<Span> = if is_selected && !msg.is_outgoing {
-                        let mut s = vec![Span::styled(gutter, gutter_style)];
-                        s.extend(split_line_with_urls(text_line).into_iter().map(
-                            |(seg, is_url)| {
-                                if is_url {
-                                    Span::styled(
-                                        seg.to_string(),
-                                        select_bg
-                                            .fg(Color::LightBlue)
-                                            .add_modifier(Modifier::UNDERLINED),
-                                    )
-                                } else {
-                                    Span::styled(seg.to_string(), select_bg.fg(msg_color))
-                                }
-                            },
-                        ));
-                        s
-                    } else {
-                        split_line_with_urls(text_line)
-                            .into_iter()
-                            .map(|(seg, is_url)| {
-                                if is_url {
-                                    Span::styled(
-                                        seg.to_string(),
-                                        if is_selected {
-                                            select_bg
-                                                .fg(Color::LightBlue)
-                                                .add_modifier(Modifier::UNDERLINED)
-                                        } else {
-                                            url_style
-                                        },
-                                    )
-                                } else {
-                                    Span::styled(
-                                        seg.to_string(),
-                                        if is_selected {
-                                            select_bg.fg(msg_color)
-                                        } else {
-                                            Style::default().fg(msg_color)
-                                        },
-                                    )
-                                }
-                            })
-                            .collect()
-                    };
-                    Line::from(spans)
+                    Line::from(vec![
+                        Span::raw(" ".repeat(pad)),
+                        Span::styled(sender_display.clone(), Style::default().fg(Color::Cyan)),
+                        Span::styled(format!(" {}", time), Style::default().fg(Color::DarkGray)),
+                    ])
                 };
-                if msg.is_outgoing {
-                    lines.push(line.alignment(Alignment::Right));
+                lines.push(header_line);
+            }
+
+            let max_self_w = (area_w * 2 / 3).max(20);
+            let content_text = msg.content.as_text().to_string();
+            let mut all_wrapped: Vec<String> = Vec::new();
+            for original_line in content_text.split('\n') {
+                all_wrapped.extend(wrap_to_width(original_line, max_self_w));
+            }
+            let total = all_wrapped.len();
+            for (li, text_line) in all_wrapped.iter().enumerate() {
+                let is_last = li == total - 1;
+                let line_w = UnicodeWidthStr::width(text_line.as_str());
+                let mut spans: Vec<Span> = build_content_spans(text_line, is_selected, Color::White);
+                if is_last {
+                    let status_w = display_width_of_status(msg.status);
+                    let pad = area_w.saturating_sub(line_w + 2 + 1 + status_w);
+                    let mut row: Vec<Span> = vec![Span::raw(" ".repeat(pad))];
+                    row.append(&mut spans);
+                    row.push(Span::styled(" ┃", Style::default().fg(Color::Cyan).bg(if is_selected { Color::Blue } else { Color::Black })));
+                    row.push(Span::raw(" "));
+                    row.push({
+                        let mut s = status_span(msg.status);
+                        if is_selected { s = s.patch_style(Style::default().bg(Color::Blue)); }
+                        s
+                    });
+                    lines.push(Line::from(row));
                 } else {
-                    lines.push(line);
+                    let pad = area_w.saturating_sub(line_w + 2);
+                    let mut row: Vec<Span> = vec![Span::raw(" ".repeat(pad))];
+                    row.append(&mut spans);
+                    row.push(Span::styled(" ┃", Style::default().fg(Color::Cyan).bg(if is_selected { Color::Blue } else { Color::Black })));
+                    lines.push(Line::from(row));
                 }
-            } // end wrap_to_width loop
-        } // end original_line loop
-        lines.push(Line::from("")); // spacing
-    }
+            }
+        } else {
+            // ── Incoming: left-aligned, purple ┃ ─────────────────────────────
+            let is_new = new_start_idx.map(|s| i >= s).unwrap_or(false);
+            let name_color = if is_new { Color::Yellow } else { Color::Magenta };
+            let bar_color = if is_new { Color::Yellow } else { Color::Magenta };
+            let msg_color = if is_new { Color::White } else { Color::Gray };
+
+            if is_group_start {
+                let header_line = if is_selected {
+                    Line::from(vec![
+                        Span::styled("▌ ", Style::default().fg(Color::Cyan).bg(Color::Blue)),
+                        Span::styled(sender_display.clone(), Style::default().fg(name_color).bg(Color::Blue)),
+                        Span::styled(format!(" {}", time), Style::default().fg(Color::DarkGray).bg(Color::Blue)),
+                    ])
+                } else {
+                    Line::from(vec![
+                        Span::styled("┃ ", Style::default().fg(bar_color)),
+                        Span::styled(sender_display.clone(), Style::default().fg(name_color)),
+                        Span::styled(format!(" {}", time), Style::default().fg(Color::DarkGray)),
+                    ])
+                };
+                lines.push(header_line);
+            }
+
+            let content_w = area_w.saturating_sub(2); // "┃ " = 2 cols
+            let content_text = msg.content.as_text().to_string();
+            for original_line in content_text.split('\n') {
+                for text_line in wrap_to_width(original_line, content_w) {
+                    let bar = if is_selected {
+                        Span::styled("▌ ", Style::default().fg(Color::Cyan).bg(Color::Blue))
+                    } else {
+                        Span::styled("┃ ", Style::default().fg(bar_color))
+                    };
+                    let mut content_spans = build_content_spans(&text_line, is_selected, msg_color);
+                    let mut row = vec![bar];
+                    row.append(&mut content_spans);
+                    lines.push(Line::from(row));
+                }
+            }
+        }
+    } // end message loop
 
     // Padding so the last message is never clipped by word-wrap miscalculation
     lines.push(Line::from(""));
@@ -338,34 +372,12 @@ pub fn render_message_view(
     lines.push(Line::from(""));
     lines.push(Line::from(""));
 
-    // Auto-scroll: estimate total visual lines accounting for word-wrap.
-    // We use ceiling division (no +1 per line) to avoid over-estimating, and
-    // rely on the 4 blank padding lines above to absorb any remaining error.
-    let visible_height = area.height.saturating_sub(2) as usize; // subtract borders
-    let content_width = area.width.saturating_sub(2) as usize; // subtract borders
-    let bubble_max_w = (content_width * 70 / 100).max(20);
-    let total_lines: usize = lines
-        .iter()
-        .map(|line| {
-            if content_width == 0 {
-                return 1;
-            }
-            let line_width: usize = line
-                .spans
-                .iter()
-                .map(|s| UnicodeWidthStr::width(s.content.as_ref()))
-                .sum();
-            if line_width == 0 {
-                1
-            } else {
-                // ceiling division: how many rows does this line occupy after wrapping?
-                // Use bubble_max_w since message lines are pre-wrapped to that width.
-                line_width.div_ceil(bubble_max_w)
-            }
-        })
-        .sum();
+    // Auto-scroll: each Line in `lines` is a pre-wrapped single terminal row
+    // (Wrap is not set on the Paragraph, so no re-wrapping occurs at render time).
+    let visible_height = area.height.saturating_sub(2) as usize;
+    let total_lines = lines.len();
     let auto_scroll = if total_lines > visible_height {
-        (total_lines - visible_height) as u16
+        u16::try_from(total_lines - visible_height).unwrap_or(u16::MAX)
     } else {
         0
     };
@@ -380,7 +392,6 @@ pub fn render_message_view(
 
     let paragraph = Paragraph::new(lines)
         .block(block)
-        .wrap(Wrap { trim: false })
         .scroll((effective_scroll, 0));
 
     f.render_widget(paragraph, area);
@@ -388,7 +399,7 @@ pub fn render_message_view(
 
 #[cfg(test)]
 mod tests {
-    use super::{split_line_with_urls, wrap_to_width};
+    use super::{display_width_of_status, split_line_with_urls, status_span, wrap_to_width};
 
     #[test]
     fn plain_text_no_url() {
@@ -532,5 +543,39 @@ mod tests {
     fn wrap_emoji_does_not_split_mid_codepoint() {
         // "🎉🎊" at max_w=3 — "🎉" is width 2 (fits), "🎊" is width 2 (new line)
         assert_eq!(wrap_to_width("🎉🎊", 3), vec!["🎉", "🎊"]);
+    }
+
+    #[test]
+    fn status_width_all_variants() {
+        use crate::core::types::MessageStatus;
+        assert_eq!(display_width_of_status(MessageStatus::Sending), 3);
+        assert_eq!(display_width_of_status(MessageStatus::Sent), 1);
+        assert_eq!(display_width_of_status(MessageStatus::Delivered), 2);
+        assert_eq!(display_width_of_status(MessageStatus::Read), 2);
+        assert_eq!(display_width_of_status(MessageStatus::Failed), 1);
+    }
+
+    #[test]
+    fn status_span_content_and_color() {
+        use crate::core::types::MessageStatus;
+        use ratatui::style::Color;
+        assert_eq!(status_span(MessageStatus::Sending).content.as_ref(), "···");
+        assert_eq!(status_span(MessageStatus::Sent).content.as_ref(), "✓");
+        assert_eq!(status_span(MessageStatus::Delivered).content.as_ref(), "✓✓");
+        assert_eq!(status_span(MessageStatus::Read).content.as_ref(), "✓✓");
+        assert_eq!(status_span(MessageStatus::Failed).content.as_ref(), "✗");
+        assert_eq!(status_span(MessageStatus::Read).style.fg, Some(Color::Green));
+        assert_eq!(status_span(MessageStatus::Failed).style.fg, Some(Color::Red));
+    }
+
+    #[test]
+    fn pre_wrap_one_line_per_terminal_row() {
+        // 50-char string at max_w=40 wraps to 2 lines
+        let text = "a".repeat(50);
+        let wrapped = wrap_to_width(&text, 40);
+        assert_eq!(wrapped.len(), 2);
+        // 50-char string at max_w=60 stays 1 line
+        let wrapped2 = wrap_to_width(&text, 60);
+        assert_eq!(wrapped2.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

Two parallel visual enhancements inspired by btop's UI design philosophy:

- **Feature F — Colored-bar message bubbles**: Replace the `▌`/`▐` gutter with colored `┃` vertical bars. Incoming messages get a left purple `┃` with name/timestamp header on group start. Outgoing messages are right-aligned with a cyan `┃` and delivery status indicator (`···` / `✓` / `✓✓` / `✓✓` green / `✗`). Groups are separated by a blank line when direction flips, sender changes, or >5min time gap.

- **Feature C — Activity graph column**: A 10-character Braille sparkline showing 24h message frequency per chat appears in a 12-col side column of the chat list when terminal width ≥ 100. Green for chats with unread messages, DarkGray otherwise. Cache refreshes every ~5 minutes with an immediate slot-23 increment on new messages.

## Files changed

| File | Change |
|------|--------|
| `src/tui/widgets/message_view.rs` | Colored `┃` bubbles, group headers, delivery status, pre-wrap scroll fix |
| `src/tui/widgets/chat_list.rs` | Horizontal split + borderless graph column |
| `src/tui/render.rs` | Pass `activity_cache` to `render_chat_list` |
| `src/tui/app_state.rs` | `activity_cache` + `activity_last_refresh_tick` fields |
| `src/app.rs` | `refresh_activity_cache` wired at startup, tick, and new message |
| `src/storage/activity.rs` | **New** — Braille encoder + 24h SQL query |
| `src/storage/mod.rs` | Register `pub mod activity` |
| `docs/superpowers/specs/` | Design spec |
| `docs/superpowers/plans/` | Implementation plan |

## Test plan

- [ ] `cargo test` — 94 tests pass, 0 failures
- [ ] `cargo build` — clean build, no new warnings
- [ ] Verify colored bubbles at any terminal width: incoming purple `┃` left, outgoing cyan `┃` right with delivery status
- [ ] Verify group separators (blank line) appear on direction/sender change and >5min gap
- [ ] Verify `▌`/`▐` selection markers still work in MessageSelect mode
- [ ] Verify activity graph column appears at ≥100 cols, disappears at <100 cols
- [ ] Verify green sparklines for unread chats, DarkGray for read chats

🤖 Generated with [Claude Code](https://claude.com/claude-code)